### PR TITLE
Remove the database migration and fix the Genesis output index

### DIFF
--- a/chain/src/store.rs
+++ b/chain/src/store.rs
@@ -34,7 +34,6 @@ const HEAD_PREFIX: u8 = 'H' as u8;
 const TAIL_PREFIX: u8 = 'T' as u8;
 const HEADER_HEAD_PREFIX: u8 = 'I' as u8;
 const SYNC_HEAD_PREFIX: u8 = 's' as u8;
-const COMMIT_POS_PREFIX: u8 = 'c' as u8;
 const COMMIT_POS_HGT_PREFIX: u8 = 'p' as u8;
 const TXKERNEL_POS_PREFIX: u8 = 'k' as u8;
 const BLOCK_INPUT_BITMAP_PREFIX: u8 = 'B' as u8;
@@ -116,16 +115,6 @@ impl ChainStore {
 				.get_ser(&to_key(BLOCK_HEADER_PREFIX, &mut h.to_vec())),
 			|| format!("BLOCK HEADER: {}", h),
 		)
-	}
-
-	/// Get all outputs PMMR pos. (only for migration purpose)
-	pub fn get_all_output_pos(&self) -> Result<Vec<(Commitment, u64)>, Error> {
-		let mut outputs_pos = Vec::new();
-		let key = to_key(COMMIT_POS_PREFIX, &mut "".to_string().into_bytes());
-		for (k, pos) in self.db.iter::<u64>(&key)? {
-			outputs_pos.push((Commitment::from_vec(k[2..].to_vec()), pos));
-		}
-		Ok(outputs_pos)
 	}
 
 	/// Get PMMR pos for the given output commitment.
@@ -337,15 +326,6 @@ impl<'a> Batch<'a> {
 			)),
 			|| format!("Output position for commit: {:?}", commit),
 		)
-	}
-
-	/// Clear all entries from the output_pos index. (only for migration purpose)
-	pub fn clear_output_pos(&self) -> Result<(), Error> {
-		let key = to_key(COMMIT_POS_PREFIX, &mut "".to_string().into_bytes());
-		for (k, _) in self.db.iter::<u64>(&key)? {
-			self.db.delete(&k)?;
-		}
-		Ok(())
 	}
 
 	/// Clear all entries from the (output_pos,height) index (must be rebuilt after).

--- a/servers/src/gotts/server.rs
+++ b/servers/src/gotts/server.rs
@@ -195,8 +195,7 @@ impl Server {
 			pruning_kernel_index,
 		)?);
 
-		// launching the database migration if needed
-		shared_chain.rebuild_height_for_pos()?;
+		shared_chain.init_genesis_height_pos_index()?;
 		// build the tx kernel mmr position index if needed
 		shared_chain.build_txkernel_pos()?;
 


### PR DESCRIPTION
- No need the database migration since no "old" version running. Removing the `COMMIT_POS_PREFIX` completely, and only use `COMMIT_POS_HGT_PREFIX` index.
- Fix for the unspent Genesis output index problem, add a `init_genesis_height_pos_index` function to initialize it when node start up.

Before this fixing:
```sh
$ curl -0 -XGET  -u gotts:`cat ~/.gotts/floo/.api_secret`  http://127.0.0.1:13513/v1/txhashset/outputs?start_index=1\&max=1

{
  "highest_index": 303,
  "last_retrieved_index": 1,
  "outputs": [
    {
      "output": {
        "features": {
          "Coinbase": {
            "spath": "9c9af651f2111dc5d529a760d5c42ea24d572589453f38982a9984c7"
          }
        },
        "commit": "0973513433682b8f4224a7a1bf387755a0642b54ca129eb4bc2946bd8e83fb54b4",
        "value": 60000000000
      },
      "output_type": "Coinbase",
      "spent": true,
      "block_height": null,
      "merkle_proof": null,
      "mmr_index": 0
    }
  ]
}
```

After this fixing:
```sh
$ curl -0 -XGET  -u gotts:`cat ~/.gotts/floo/.api_secret`  http://127.0.0.1:13513/v1/txhashset/outputs?start_index=1\&max=1
{
  "highest_index": 303,
  "last_retrieved_index": 1,
  "outputs": [
    {
      "output": {
        "features": {
          "Coinbase": {
            "spath": "9c9af651f2111dc5d529a760d5c42ea24d572589453f38982a9984c7"
          }
        },
        "commit": "0973513433682b8f4224a7a1bf387755a0642b54ca129eb4bc2946bd8e83fb54b4",
        "value": 60000000000
      },
      "output_type": "Coinbase",
      "spent": false,
      "block_height": 0,
      "merkle_proof": null,
      "mmr_index": 1
    }
  ]
}
```