### PR TITLE
Remove the transaction offset which has no value in Gotts

### DIFF
--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -1561,7 +1561,7 @@ fn setup_head(
 
 			if genesis.kernels().len() > 0 {
 				let (utxo_sum, kernel_sum) = (sums, genesis as &dyn Committed)
-					.verify_kernel_sums(genesis.header.total_kernel_offset())?;
+					.verify_kernel_sums()?;
 				sums = BlockSums {
 					utxo_sum,
 					kernel_sum,

--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -1560,8 +1560,8 @@ fn setup_head(
 			batch.save_header_head(&tip)?;
 
 			if genesis.kernels().len() > 0 {
-				let (utxo_sum, kernel_sum) = (sums, genesis as &dyn Committed)
-					.verify_kernel_sums()?;
+				let (utxo_sum, kernel_sum) =
+					(sums, genesis as &dyn Committed).verify_kernel_sums()?;
 				sums = BlockSums {
 					utxo_sum,
 					kernel_sum,

--- a/chain/src/pipe.rs
+++ b/chain/src/pipe.rs
@@ -405,9 +405,9 @@ fn validate_header(header: &BlockHeader, ctx: &mut BlockContext<'_>) -> Result<(
 }
 
 fn validate_block(block: &Block, ctx: &mut BlockContext<'_>) -> Result<(), Error> {
-	let prev = ctx.batch.get_previous_header(&block.header)?;
+	let _prev = ctx.batch.get_previous_header(&block.header)?;
 	block
-		.validate(&prev.total_kernel_offset, ctx.verifier_cache.clone())
+		.validate(ctx.verifier_cache.clone())
 		.map_err(|e| ErrorKind::InvalidBlockProof(e))?;
 	Ok(())
 }
@@ -451,12 +451,9 @@ fn verify_block_sums(
 		return Err(ErrorKind::BlockSumMismatch)?;
 	}
 
-	// Offset on the other hand is the total kernel offset from the new block.
-	let offset = b.header.total_kernel_offset();
-
 	// Verify the kernel sums for the block_sums with the new block applied.
 	let (utxo_sum, kernel_sum) =
-		(previous_block_sums, b as &dyn Committed).verify_kernel_sums(offset)?;
+		(previous_block_sums, b as &dyn Committed).verify_kernel_sums()?;
 
 	Ok(BlockSums {
 		utxo_sum,

--- a/chain/src/pipe.rs
+++ b/chain/src/pipe.rs
@@ -452,8 +452,7 @@ fn verify_block_sums(
 	}
 
 	// Verify the kernel sums for the block_sums with the new block applied.
-	let (utxo_sum, kernel_sum) =
-		(previous_block_sums, b as &dyn Committed).verify_kernel_sums()?;
+	let (utxo_sum, kernel_sum) = (previous_block_sums, b as &dyn Committed).verify_kernel_sums()?;
 
 	Ok(BlockSums {
 		utxo_sum,

--- a/chain/src/txhashset/txhashset.rs
+++ b/chain/src/txhashset/txhashset.rs
@@ -1089,7 +1089,7 @@ impl<'a> Extension<'a> {
 		let now = Instant::now();
 
 		let head_header = self.batch.get_block_header(&self.head.last_block_h)?;
-		let (utxo_sum, kernel_sum) = self.verify_kernel_sums(head_header.total_kernel_offset())?;
+		let (utxo_sum, kernel_sum) = self.verify_kernel_sums()?;
 		//todo: total overage validation
 		let _overage = head_header.total_overage(genesis.kernel_mmr_size > 0);
 

--- a/core/src/core/block.rs
+++ b/core/src/core/block.rs
@@ -681,10 +681,7 @@ impl Block {
 	/// Validates all the elements in a block that can be checked without
 	/// additional data. Includes commitment sums and kernels, Merkle
 	/// trees, reward, etc.
-	pub fn validate(
-		&self,
-		verifier: Arc<RwLock<dyn VerifierCache>>,
-	) -> Result<Commitment, Error> {
+	pub fn validate(&self, verifier: Arc<RwLock<dyn VerifierCache>>) -> Result<Commitment, Error> {
 		self.body.validate(Weighting::AsBlock, verifier)?;
 
 		self.verify_kernel_lock_heights()?;

--- a/core/tests/block.rs
+++ b/core/tests/block.rs
@@ -67,9 +67,7 @@ fn too_large_block() {
 	let prev = BlockHeader::default();
 	let key_id = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
 	let b = new_block(vec![&tx], &keychain, &builder, &prev, &key_id);
-	assert!(b
-		.validate(verifier_cache())
-		.is_err());
+	assert!(b.validate(verifier_cache()).is_err());
 }
 
 #[test]
@@ -117,8 +115,7 @@ fn block_with_cut_through() {
 
 	// block should have been automatically compacted (including reward
 	// output) and should still be valid
-	b.validate(verifier_cache())
-		.unwrap();
+	b.validate(verifier_cache()).unwrap();
 	assert_eq!(b.inputs().len(), 3);
 	assert_eq!(b.outputs().len(), 3);
 }
@@ -153,9 +150,7 @@ fn empty_block_with_coinbase_is_valid() {
 
 	// the block should be valid here (single coinbase output with corresponding
 	// txn kernel)
-	assert!(b
-		.validate(verifier_cache())
-		.is_ok());
+	assert!(b.validate(verifier_cache()).is_ok());
 }
 
 #[test]

--- a/core/tests/block.rs
+++ b/core/tests/block.rs
@@ -28,7 +28,7 @@ use crate::core::core::{
 use crate::core::libtx::build::{self, input, output, with_fee};
 use crate::core::libtx::ProofBuilder;
 use crate::core::{global, ser};
-use crate::keychain::{BlindingFactor, ExtKeychain, Keychain};
+use crate::keychain::{ExtKeychain, Keychain};
 use crate::util::RwLock;
 use chrono::Duration;
 use gotts_core as core;
@@ -68,7 +68,7 @@ fn too_large_block() {
 	let key_id = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
 	let b = new_block(vec![&tx], &keychain, &builder, &prev, &key_id);
 	assert!(b
-		.validate(&BlindingFactor::zero(), verifier_cache())
+		.validate(verifier_cache())
 		.is_err());
 }
 
@@ -117,7 +117,7 @@ fn block_with_cut_through() {
 
 	// block should have been automatically compacted (including reward
 	// output) and should still be valid
-	b.validate(&BlindingFactor::zero(), verifier_cache())
+	b.validate(verifier_cache())
 		.unwrap();
 	assert_eq!(b.inputs().len(), 3);
 	assert_eq!(b.outputs().len(), 3);
@@ -154,7 +154,7 @@ fn empty_block_with_coinbase_is_valid() {
 	// the block should be valid here (single coinbase output with corresponding
 	// txn kernel)
 	assert!(b
-		.validate(&BlindingFactor::zero(), verifier_cache())
+		.validate(verifier_cache())
 		.is_ok());
 }
 
@@ -175,9 +175,9 @@ fn remove_coinbase_output_flag() {
 	};
 
 	assert_eq!(b.verify_coinbase(), Err(Error::CoinbaseSumMismatch));
-	assert!(b.verify_kernel_sums(b.header.total_kernel_offset()).is_ok());
+	assert!(b.verify_kernel_sums().is_ok());
 	assert_eq!(
-		b.validate(&BlindingFactor::zero(), verifier_cache()),
+		b.validate(verifier_cache()),
 		Err(Error::CoinbaseSumMismatch)
 	);
 }
@@ -201,7 +201,7 @@ fn remove_coinbase_kernel_flag() {
 	// Also results in the block no longer validating correctly
 	// because the message being signed on each tx kernel includes the kernel features.
 	assert_eq!(
-		b.validate(&BlindingFactor::zero(), verifier_cache()),
+		b.validate(verifier_cache()),
 		Err(Error::Transaction(transaction::Error::IncorrectSignature))
 	);
 }

--- a/core/tests/core.rs
+++ b/core/tests/core.rs
@@ -27,7 +27,7 @@ use self::core::libtx::build::{
 };
 use self::core::libtx::ProofBuilder;
 use self::core::ser;
-use self::keychain::{BlindingFactor, ExtKeychain, Keychain};
+use self::keychain::{ExtKeychain, Keychain};
 use self::util::RwLock;
 use crate::common::{new_block, tx1i1o, tx1i2o, tx2i1o};
 use gotts_core as core;
@@ -39,10 +39,17 @@ use std::sync::Arc;
 #[test]
 fn simple_tx_ser() {
 	let tx = tx2i1o();
+	let mut vec = Vec::new();
+	ser::serialize_default(&mut vec, &tx).expect("serialization failed");
+	let target_len = 276;
+	assert_eq!(vec.len(), target_len,);
+
+	let tx = tx1i2o();
 	println!("tx = {}", serde_json::to_string_pretty(&tx).unwrap());
 	let mut vec = Vec::new();
 	ser::serialize_default(&mut vec, &tx).expect("serialization failed");
-	let target_len = 308;
+	let target_len = 312;
+	println!("tx vec = {:02x?}", vec);
 	assert_eq!(vec.len(), target_len,);
 }
 
@@ -76,22 +83,20 @@ fn tx_double_ser_deser() {
 }
 
 #[test]
-#[should_panic(expected = "Keychain Error")]
 fn test_zero_commit_fails() {
 	let keychain = ExtKeychain::from_random_seed(false).unwrap();
 	let builder = ProofBuilder::new(&keychain);
 	let key_id1 = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
 
 	// blinding should fail as signing with a zero r*G shouldn't work
-	build::transaction(
+	assert!(build::transaction(
 		vec![
 			input(10, 0i64, key_id1.clone()),
 			output(10, Some(0i64), key_id1.clone()),
 		],
 		&keychain,
 		&builder,
-	)
-	.unwrap();
+	).is_err());
 }
 
 fn verifier_cache() -> Arc<RwLock<dyn VerifierCache>> {
@@ -454,7 +459,7 @@ fn reward_empty_block() {
 
 	b.cut_through()
 		.unwrap()
-		.validate(&BlindingFactor::zero(), verifier_cache())
+		.validate(verifier_cache())
 		.unwrap();
 }
 
@@ -481,7 +486,7 @@ fn reward_with_tx_block() {
 	block
 		.cut_through()
 		.unwrap()
-		.validate(&BlindingFactor::zero(), vc.clone())
+		.validate(vc.clone())
 		.unwrap();
 }
 
@@ -505,7 +510,7 @@ fn simple_block() {
 		&key_id,
 	);
 
-	b.validate(&BlindingFactor::zero(), vc.clone()).unwrap();
+	b.validate(vc.clone()).unwrap();
 }
 
 #[test]
@@ -541,7 +546,7 @@ fn test_block_with_timelocked_tx() {
 		&previous_header,
 		&key_id3.clone(),
 	);
-	b.validate(&BlindingFactor::zero(), vc.clone()).unwrap();
+	b.validate(vc.clone()).unwrap();
 
 	// now try adding a timelocked tx where lock height is greater than current
 	// block height
@@ -566,7 +571,7 @@ fn test_block_with_timelocked_tx() {
 		&key_id3.clone(),
 	);
 
-	match b.validate(&BlindingFactor::zero(), vc.clone()) {
+	match b.validate(vc.clone()) {
 		Err(KernelLockHeight(height)) => {
 			assert_eq!(height, 2);
 		}

--- a/core/tests/core.rs
+++ b/core/tests/core.rs
@@ -96,7 +96,8 @@ fn test_zero_commit_fails() {
 		],
 		&keychain,
 		&builder,
-	).is_err());
+	)
+	.is_err());
 }
 
 fn verifier_cache() -> Arc<RwLock<dyn VerifierCache>> {
@@ -457,10 +458,7 @@ fn reward_empty_block() {
 
 	let b = new_block(vec![], &keychain, &builder, &previous_header, &key_id);
 
-	b.cut_through()
-		.unwrap()
-		.validate(verifier_cache())
-		.unwrap();
+	b.cut_through().unwrap().validate(verifier_cache()).unwrap();
 }
 
 #[test]
@@ -483,11 +481,7 @@ fn reward_with_tx_block() {
 		&previous_header,
 		&key_id,
 	);
-	block
-		.cut_through()
-		.unwrap()
-		.validate(vc.clone())
-		.unwrap();
+	block.cut_through().unwrap().validate(vc.clone()).unwrap();
 }
 
 #[test]

--- a/pool/src/pool.rs
+++ b/pool/src/pool.rs
@@ -269,14 +269,13 @@ impl Pool {
 		header: &BlockHeader,
 	) -> Result<BlockSums, PoolError> {
 		let _overage = tx.overage();
-		let offset = (header.total_kernel_offset() + tx.offset.clone())?;
 
 		let block_sums = self.blockchain.get_block_sums(&header.hash())?;
 
 		// Verify the kernel sums for the block_sums with the new tx applied,
 		// accounting for overage and offset.
 		let (utxo_sum, kernel_sum) =
-			(block_sums, tx as &dyn Committed).verify_kernel_sums(offset)?;
+			(block_sums, tx as &dyn Committed).verify_kernel_sums()?;
 
 		Ok(BlockSums {
 			utxo_sum,

--- a/pool/src/pool.rs
+++ b/pool/src/pool.rs
@@ -274,8 +274,7 @@ impl Pool {
 
 		// Verify the kernel sums for the block_sums with the new tx applied,
 		// accounting for overage and offset.
-		let (utxo_sum, kernel_sum) =
-			(block_sums, tx as &dyn Committed).verify_kernel_sums()?;
+		let (utxo_sum, kernel_sum) = (block_sums, tx as &dyn Committed).verify_kernel_sums()?;
 
 		Ok(BlockSums {
 			utxo_sum,

--- a/pool/tests/common.rs
+++ b/pool/tests/common.rs
@@ -73,12 +73,9 @@ impl ChainAdapter {
 		// Previous block_sums have taken all previous overage into account.
 		let _overage = header.overage();
 
-		// Offset on the other hand is the total kernel offset from the new block.
-		let offset = header.total_kernel_offset();
-
 		// Verify the kernel sums for the block_sums with the new block applied.
 		let (utxo_sum, kernel_sum) = (prev_sums, block as &dyn Committed)
-			.verify_kernel_sums(offset)
+			.verify_kernel_sums()
 			.unwrap();
 
 		let block_sums = BlockSums {

--- a/servers/src/common/adapters.rs
+++ b/servers/src/common/adapters.rs
@@ -212,9 +212,9 @@ impl p2p::ChainAdapter for NetToChainAdapter {
 				}
 			};
 
-			if let Ok(prev) = self.chain().get_previous_header(&cb.header) {
+			if let Ok(_prev) = self.chain().get_previous_header(&cb.header) {
 				if block
-					.validate(&prev.total_kernel_offset, self.verifier_cache.clone())
+					.validate(self.verifier_cache.clone())
 					.is_ok()
 				{
 					debug!("successfully hydrated block from tx pool!");

--- a/servers/src/common/adapters.rs
+++ b/servers/src/common/adapters.rs
@@ -213,10 +213,7 @@ impl p2p::ChainAdapter for NetToChainAdapter {
 			};
 
 			if let Ok(_prev) = self.chain().get_previous_header(&cb.header) {
-				if block
-					.validate(self.verifier_cache.clone())
-					.is_ok()
-				{
+				if block.validate(self.verifier_cache.clone()).is_ok() {
 					debug!("successfully hydrated block from tx pool!");
 					self.process_block(block, peer_info, false)
 				} else {

--- a/servers/src/mining/mine_block.rs
+++ b/servers/src/mining/mine_block.rs
@@ -181,7 +181,7 @@ fn build_block(
 	let mut b = core::Block::from_reward(&head, txs, output, kernel, difficulty.difficulty)?;
 
 	// making sure we're not spending time mining a useless block
-	b.validate(&head.total_kernel_offset, verifier_cache)?;
+	b.validate(verifier_cache)?;
 
 	b.header.pow.nonce = thread_rng().gen();
 	b.header.pow.secondary_scaling = difficulty.secondary_scaling;


### PR DESCRIPTION
The `offset` is used to solve the [subset-sum problem](https://github.com/garyyu/rust-secp256k1-zkp/wiki/%22Subset-Sum%22-Problem) in MimbleWimble.

But in Gotts, since we use public value, it's always possible to find out the original transaction graph (i.e. relationships between Inputs and Outputs) by the public values. The objective of Gotts is NOT a pure privacy coin anymore, the public value definitely has the consequence of a public transaction graph.

So, let's remove this `offset`, to save 32 bytes for transaction data. Also, the `total offset` in block header will be removed later.

