### PR TITLE
Remove the 'total_kernel_offset' from the BlockHeader

### DIFF
--- a/api/src/types.rs
+++ b/api/src/types.rs
@@ -284,8 +284,6 @@ pub struct BlockHeaderPrintable {
 	pub total_difficulty: u64,
 	/// Variable difficulty scaling factor for secondary proof of work
 	pub secondary_scaling: u32,
-	/// Total kernel offset since genesis block
-	pub total_kernel_offset: String,
 }
 
 impl BlockHeaderPrintable {
@@ -305,7 +303,6 @@ impl BlockHeaderPrintable {
 			cuckoo_solution: header.pow.proof.nonces.clone(),
 			total_difficulty: header.pow.total_difficulty.to_num(),
 			secondary_scaling: header.pow.secondary_scaling,
-			total_kernel_offset: header.total_kernel_offset.to_hex(),
 		}
 	}
 }

--- a/core/src/genesis.rs
+++ b/core/src/genesis.rs
@@ -31,7 +31,6 @@ use crate::util::secp::pedersen::Commitment;
 use crate::util::secp::Signature;
 
 use crate::core::hash::Hash;
-use crate::keychain::BlindingFactor;
 
 /// Genesis block definition for development networks. The proof of work size
 /// is small enough to mine it on the fly, so it does not contain its own
@@ -67,10 +66,6 @@ pub fn genesis_floo() -> core::Block {
 		.unwrap(),
 		kernel_root: Hash::from_hex(
 			"72d28ce7d3f09e28f8c668ea823eeb90829af76872e9295f0374307b1747746b",
-		)
-		.unwrap(),
-		total_kernel_offset: BlindingFactor::from_hex(
-			"0000000000000000000000000000000000000000000000000000000000000000",
 		)
 		.unwrap(),
 		output_mmr_size: 1,
@@ -138,7 +133,6 @@ pub fn genesis_main() -> core::Block {
 		output_root: Hash::default(),                      // REPLACE
 		range_proof_root: Hash::default(),                 // REPLACE
 		kernel_root: Hash::default(),                      // REPLACE
-		total_kernel_offset: BlindingFactor::zero(),       // REPLACE
 		output_mmr_size: 1,
 		kernel_mmr_size: 1,
 		pow: ProofOfWork {
@@ -185,7 +179,7 @@ mod test {
 		);
 		assert_eq!(
 			gen_bin.hash().to_hex(),
-			"b50d74014c8315d115101bf1490d02fef1cbdda26b728758aa9187ccd4c618cf"
+			"676df90213f00f29a81a365f8a1235f0c4957b4a6c79845bf5668d7f0c840d1f"
 		);
 	}
 
@@ -201,7 +195,7 @@ mod test {
 		);
 		assert_eq!(
 			gen_bin.hash().to_hex(),
-			"83cadf68794eb38fe195bd780b08e9b9cd5ff15d9f24aaf71d7b432622167d9a"
+			"80ccaa1536bb2b0080886f8a79bc45a3eb9e43619f20b0223a4fd7ab1d0d6ff6"
 		);
 	}
 }

--- a/core/tests/block.rs
+++ b/core/tests/block.rs
@@ -265,7 +265,7 @@ fn empty_block_serialized_size() {
 	let b = new_block(vec![], &keychain, &builder, &prev, &key_id);
 	let mut vec = Vec::new();
 	ser::serialize_default(&mut vec, &b).expect("serialization failed");
-	let target_len = 465;
+	let target_len = 433;
 	assert_eq!(vec.len(), target_len);
 }
 
@@ -280,7 +280,7 @@ fn block_single_tx_serialized_size() {
 	let b = new_block(vec![&tx1], &keychain, &builder, &prev, &key_id);
 	let mut vec = Vec::new();
 	ser::serialize_default(&mut vec, &b).expect("serialization failed");
-	let target_len = 753;
+	let target_len = 721;
 	assert_eq!(vec.len(), target_len);
 }
 
@@ -295,7 +295,7 @@ fn empty_compact_block_serialized_size() {
 	let cb: CompactBlock = b.into();
 	let mut vec = Vec::new();
 	ser::serialize_default(&mut vec, &cb).expect("serialization failed");
-	let target_len = 473;
+	let target_len = 441;
 	assert_eq!(vec.len(), target_len);
 }
 
@@ -311,7 +311,7 @@ fn compact_block_single_tx_serialized_size() {
 	let cb: CompactBlock = b.into();
 	let mut vec = Vec::new();
 	ser::serialize_default(&mut vec, &cb).expect("serialization failed");
-	let target_len = 479;
+	let target_len = 447;
 	assert_eq!(vec.len(), target_len);
 }
 
@@ -331,7 +331,7 @@ fn block_10_tx_serialized_size() {
 	let b = new_block(txs.iter().collect(), &keychain, &builder, &prev, &key_id);
 	let mut vec = Vec::new();
 	ser::serialize_default(&mut vec, &b).expect("serialization failed");
-	let target_len = 3_345;
+	let target_len = 3_313;
 	assert_eq!(vec.len(), target_len,);
 }
 
@@ -352,7 +352,7 @@ fn compact_block_10_tx_serialized_size() {
 	let cb: CompactBlock = b.into();
 	let mut vec = Vec::new();
 	ser::serialize_default(&mut vec, &cb).expect("serialization failed");
-	let target_len = 533;
+	let target_len = 501;
 	assert_eq!(vec.len(), target_len,);
 }
 


### PR DESCRIPTION
The consequent PR for https://github.com/gottstech/gotts/pull/7, removing `total_kernel_offset` from the block header.