### PR TITLE
fix: the chain/outputs/byids doesn't work for SigLocked UTXO

### DIFF
--- a/api/src/handlers/transactions_api.rs
+++ b/api/src/handlers/transactions_api.rs
@@ -106,7 +106,7 @@ impl TxHashSetHandler {
 			.get_merkle_proof_for_output(&id)
 			.map_err(|_| ErrorKind::NotFound)?;
 		let output = chain
-			.unspent_output_by_position(ofph.position)
+			.unspent_output_by_position(ofph.position, features)
 			.ok_or(ErrorKind::NotFound)?;
 		Ok(OutputPrintable {
 			output,

--- a/api/src/types.rs
+++ b/api/src/types.rs
@@ -170,7 +170,7 @@ impl OutputPrintable {
 		};
 
 		let out_id = core::OutputIdentifier::from_output(&output);
-		let res = chain.is_unspent(&out_id);
+		let res = chain.is_unspent(&out_id.commit);
 		let (spent, block_height) = if let Ok(output_pos) = res {
 			(false, Some(output_pos.height))
 		} else {

--- a/chain/src/types.rs
+++ b/chain/src/types.rs
@@ -226,6 +226,8 @@ pub struct OutputMMRPosition {
 	pub position: u64,
 	/// Block height
 	pub height: u64,
+	/// The output features
+	pub features: OutputFeatures,
 }
 
 /// A helper to hold the output feature, pmmr position, and height in order to keep them

--- a/chain/tests/mine_simple_chain.rs
+++ b/chain/tests/mine_simple_chain.rs
@@ -629,10 +629,10 @@ fn spend_in_fork_and_compact() {
 		assert_eq!(head.height, 6);
 		assert_eq!(head.hash(), prev_main.hash());
 		assert!(chain
-			.is_unspent(&OutputIdentifier::from_output(&tx2.outputs()[0]))
+			.is_unspent(&OutputIdentifier::from_output(&tx2.outputs()[0]).commit)
 			.is_ok());
 		assert!(chain
-			.is_unspent(&OutputIdentifier::from_output(&tx1.outputs()[0]))
+			.is_unspent(&OutputIdentifier::from_output(&tx1.outputs()[0]).commit)
 			.is_err());
 
 		// make the fork win
@@ -648,10 +648,10 @@ fn spend_in_fork_and_compact() {
 		assert_eq!(head.height, 7);
 		assert_eq!(head.hash(), prev_fork.hash());
 		assert!(chain
-			.is_unspent(&OutputIdentifier::from_output(&tx2.outputs()[0]))
+			.is_unspent(&OutputIdentifier::from_output(&tx2.outputs()[0]).commit)
 			.is_ok());
 		assert!(chain
-			.is_unspent(&OutputIdentifier::from_output(&tx1.outputs()[0]))
+			.is_unspent(&OutputIdentifier::from_output(&tx1.outputs()[0]).commit)
 			.is_err());
 
 		// add 20 blocks to go past the test horizon


### PR DESCRIPTION
The `output_i` and `output_ii` problems :-)

After this fixing, it works like this example:
```sh
$ curl -0 -XGET -u gotts:`cat ~/.gotts/floo/.api_secret`  http://127.0.0.1:13513/v1/chain/outputs/byids?id=09d3aee1dd7f6d2742e7e15c8ca6f0b486735e347520fb48f689edd7a5943c1d23

[
  {
    "output": {
      "features": {
        "SigLocked": {
          "locker": {
            "p2pkh": "ab9926027c6c037c9629b5b78b647ab8fd43a6aeef76d1d16716c7d445a1e92f",
            "pub_nonce": "027fdb417ae76708d60a47d82633c6539ac00dea11538475c9f3ec70009b5b9d66",
            "secured_w": 5264193619716105024,
            "relative_lock_height": 1
          }
        }
      },
      "commit": "09d3aee1dd7f6d2742e7e15c8ca6f0b486735e347520fb48f689edd7a5943c1d23",
      "value": 100000000000
    },
    "height": 112,
    "mmr_index": 5
  }
]

```