### PR TITLE
refact: use specific hash_with_index instead of the generic one

### DIFF
--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -599,7 +599,7 @@ impl Chain {
 
 		// Set the output, rangeproof and kernel MMR roots.
 		b.header.output_i_root = roots.output_i_root;
-		b.header.output_ii_root = roots.output_ii_root;;
+		b.header.output_ii_root = roots.output_ii_root;
 		b.header.kernel_root = roots.kernel_root;
 
 		// Set the output and kernel MMR sizes.

--- a/core/src/core/block.rs
+++ b/core/src/core/block.rs
@@ -36,7 +36,7 @@ use crate::core::{
 use crate::global;
 use crate::keychain::{self};
 use crate::pow::{Difficulty, Proof, ProofOfWork};
-use crate::ser::{self, FixedLength, PMMRable, Readable, Reader, Writeable, Writer};
+use crate::ser::{self, FixedLength, PMMRIndexHashable, PMMRable, Readable, Reader, Writeable, Writer};
 use crate::util::{secp, static_secp_instance};
 
 /// Errors thrown by Block validation
@@ -274,6 +274,12 @@ impl PMMRable for BlockHeader {
 			secondary_scaling: self.pow.secondary_scaling,
 			is_secondary: self.pow.is_secondary(),
 		}
+	}
+}
+
+impl PMMRIndexHashable for BlockHeader {
+	fn hash_with_index(&self, index: u64) -> Hash {
+		(index, self).hash()
 	}
 }
 

--- a/core/src/core/block.rs
+++ b/core/src/core/block.rs
@@ -36,7 +36,9 @@ use crate::core::{
 use crate::global;
 use crate::keychain::{self};
 use crate::pow::{Difficulty, Proof, ProofOfWork};
-use crate::ser::{self, FixedLength, PMMRIndexHashable, PMMRable, Readable, Reader, Writeable, Writer};
+use crate::ser::{
+	self, FixedLength, PMMRIndexHashable, PMMRable, Readable, Reader, Writeable, Writer,
+};
 use crate::util::{secp, static_secp_instance};
 
 /// Errors thrown by Block validation

--- a/core/src/core/hash.rs
+++ b/core/src/core/hash.rs
@@ -28,7 +28,8 @@ use crate::blake2::blake2b::Blake2b;
 
 use crate::libtx::secp_ser;
 use crate::ser::{
-	self, AsFixedBytes, Error, FixedLength, PMMRIndexHashable, ProtocolVersion, Readable, Reader, Writeable, Writer,
+	self, AsFixedBytes, Error, FixedLength, PMMRIndexHashable, ProtocolVersion, Readable, Reader,
+	Writeable, Writer,
 };
 use crate::util;
 use crate::zeroize::Zeroize;

--- a/core/src/core/hash.rs
+++ b/core/src/core/hash.rs
@@ -28,7 +28,7 @@ use crate::blake2::blake2b::Blake2b;
 
 use crate::libtx::secp_ser;
 use crate::ser::{
-	self, AsFixedBytes, Error, FixedLength, ProtocolVersion, Readable, Reader, Writeable, Writer,
+	self, AsFixedBytes, Error, FixedLength, PMMRIndexHashable, ProtocolVersion, Readable, Reader, Writeable, Writer,
 };
 use crate::util;
 use crate::zeroize::Zeroize;
@@ -48,6 +48,17 @@ pub struct Hash(
 );
 
 impl DefaultHashable for Hash {}
+
+impl PMMRIndexHashable for Hash {
+	fn hash_with_index(&self, index: u64) -> Hash {
+		(index, self).hash()
+	}
+}
+impl PMMRIndexHashable for (Hash, Hash) {
+	fn hash_with_index(&self, index: u64) -> Hash {
+		(index, self).hash()
+	}
+}
 
 impl Hash {
 	fn hash_with<T: Writeable>(&self, other: T) -> Hash {

--- a/core/src/core/pmmr/pmmr.rs
+++ b/core/src/core/pmmr/pmmr.rs
@@ -46,7 +46,7 @@ where
 	_marker: marker::PhantomData<T>,
 }
 
-impl<'a, T, B> PMMR<'a, T, B>
+impl<'a, T: PMMRIndexHashable, B> PMMR<'a, T, B>
 where
 	T: PMMRable,
 	B: 'a + Backend<T>,

--- a/core/src/core/transaction.rs
+++ b/core/src/core/transaction.rs
@@ -1219,6 +1219,7 @@ pub fn cut_through(inputs_ex: &mut Vec<InputEx>, outputs: &mut Vec<Output>) -> R
 		return Err(Error::AggregationError);
 	}
 
+	//todo: SigLocked Output cut-through, InputsWithUnlocker cut-through
 	let mut inputs: Vec<Input> = inputs_ex
 		.iter()
 		.filter(|i| !i.is_unlocker())
@@ -1333,8 +1334,7 @@ pub fn deaggregate(mk_tx: Transaction, txs: Vec<Transaction>) -> Result<Transact
 	}
 
 	// Sorting them lexicographically
-	//todo: inputs sorting
-	//inputs.sort_unstable();
+	inputs.sort_unstable();
 	outputs.sort_unstable();
 	kernels.sort_unstable();
 
@@ -1903,10 +1903,6 @@ impl PartialEq for Output {
 }
 impl Eq for Output {}
 
-/// To make it simple among all 3 types: Output, OutputI, and OutputII, we define same Hash
-/// for all of them:
-/// 1. Only the OutputIdentifier is used for Hash.
-/// 2. All 3 types (Output, OutputI, OutputII) have same Hash result.
 impl ::std::hash::Hash for Output {
 	fn hash<H: ::std::hash::Hasher>(&self, state: &mut H) {
 		let mut vec = Vec::new();

--- a/core/src/ser.rs
+++ b/core/src/ser.rs
@@ -628,6 +628,12 @@ impl PMMRable for RangeProof {
 	}
 }
 
+impl PMMRIndexHashable for RangeProof {
+	fn hash_with_index(&self, index: u64) -> Hash {
+		(index, self).hash()
+	}
+}
+
 impl Writeable for SecuredPath {
 	fn write<W: Writer>(&self, writer: &mut W) -> Result<(), Error> {
 		writer.write_fixed_bytes(self)
@@ -887,12 +893,6 @@ pub trait PMMRable: Writeable + Clone + Debug + DefaultHashable {
 pub trait PMMRIndexHashable {
 	/// Hash with a given index
 	fn hash_with_index(&self, index: u64) -> Hash;
-}
-
-impl<T: DefaultHashable> PMMRIndexHashable for T {
-	fn hash_with_index(&self, index: u64) -> Hash {
-		(index, self).hash()
-	}
 }
 
 /// Useful marker trait on types that can be sized byte slices

--- a/core/tests/vec_backend.rs
+++ b/core/tests/vec_backend.rs
@@ -19,7 +19,9 @@ use self::core::core::hash::{DefaultHashable, Hash, Hashed};
 use self::core::core::pmmr::{self, Backend};
 use self::core::core::BlockHeader;
 use self::core::ser;
-use self::core::ser::{FixedLength, PMMRIndexHashable, PMMRable, Readable, Reader, Writeable, Writer};
+use self::core::ser::{
+	FixedLength, PMMRIndexHashable, PMMRable, Readable, Reader, Writeable, Writer,
+};
 use croaring;
 use croaring::Bitmap;
 use gotts_core as core;

--- a/core/tests/vec_backend.rs
+++ b/core/tests/vec_backend.rs
@@ -15,11 +15,11 @@
 
 use std::fs::File;
 
-use self::core::core::hash::{DefaultHashable, Hash};
+use self::core::core::hash::{DefaultHashable, Hash, Hashed};
 use self::core::core::pmmr::{self, Backend};
 use self::core::core::BlockHeader;
 use self::core::ser;
-use self::core::ser::{FixedLength, PMMRable, Readable, Reader, Writeable, Writer};
+use self::core::ser::{FixedLength, PMMRIndexHashable, PMMRable, Readable, Reader, Writeable, Writer};
 use croaring;
 use croaring::Bitmap;
 use gotts_core as core;
@@ -38,6 +38,12 @@ impl PMMRable for TestElem {
 
 	fn as_elmt(&self) -> Self::E {
 		self.clone()
+	}
+}
+
+impl PMMRIndexHashable for TestElem {
+	fn hash_with_index(&self, index: u64) -> Hash {
+		(index, self).hash()
 	}
 }
 

--- a/store/tests/pmmr.rs
+++ b/store/tests/pmmr.rs
@@ -22,7 +22,7 @@ use std::fs;
 use chrono::prelude::Utc;
 use croaring::Bitmap;
 
-use crate::core::core::hash::DefaultHashable;
+use crate::core::core::hash::{DefaultHashable, Hash, Hashed};
 use crate::core::core::pmmr::{Backend, PMMR};
 use crate::core::ser::{
 	Error, FixedLength, PMMRIndexHashable, PMMRable, Readable, Reader, Writeable, Writer,
@@ -921,6 +921,12 @@ impl PMMRable for TestElem {
 
 	fn as_elmt(&self) -> Self::E {
 		self.clone()
+	}
+}
+
+impl PMMRIndexHashable for TestElem {
+	fn hash_with_index(&self, index: u64) -> Hash {
+		(index, self).hash()
 	}
 }
 


### PR DESCRIPTION
Regarding to the following designed behaviour:
```
	// Among all 3 types: Output, OutputI, and OutputII, we define same Hash
	// for all of them:
	// 1. Only the OutputIdentifier is used for Hash.
	// 2. All 3 types (Output, OutputI, OutputII) have same Hash result.
```
The benefit of this design is for the convenience of hash compare between all these types of OutputX and Input, but the consequence is the Output MMR will be same even if the detail of the OutputX are different!  That definitely is NOT what we want.

Since the MMR hash always use the `hash_with_index`, we just need to remove the universal `hash_with_index` implementation which was:
```Rust
impl<T: DefaultHashable> PMMRIndexHashable for T {
	fn hash_with_index(&self, index: u64) -> Hash {
		(index, self).hash()
	}
}
```
And use the full data of Output / OutputI / OutputII for the specific `hash_with_index` function implementation.

This is a consensus breaking change and we have to re-generate a new Genesis again, I will do it in next PR soon.

