### PR TITLE
clean-up some u64 sizes and replace with u32

### DIFF
--- a/core/src/core/compact_block.rs
+++ b/core/src/core/compact_block.rs
@@ -86,11 +86,11 @@ impl CompactBlockBody {
 impl Readable for CompactBlockBody {
 	fn read(reader: &mut dyn Reader) -> Result<CompactBlockBody, ser::Error> {
 		let (out_full_len, kern_full_len, kern_id_len) =
-			ser_multiread!(reader, read_u64, read_u64, read_u64);
+			ser_multiread!(reader, read_u32, read_u32, read_u32);
 
-		let out_full = read_multi(reader, out_full_len)?;
-		let kern_full = read_multi(reader, kern_full_len)?;
-		let kern_ids = read_multi(reader, kern_id_len)?;
+		let out_full = read_multi(reader, out_full_len as u64)?;
+		let kern_full = read_multi(reader, kern_full_len as u64)?;
+		let kern_ids = read_multi(reader, kern_id_len as u64)?;
 
 		// Initialize compact block body, verifying sort order.
 		let body = CompactBlockBody::init(out_full, kern_full, kern_ids, true)
@@ -104,9 +104,9 @@ impl Writeable for CompactBlockBody {
 	fn write<W: Writer>(&self, writer: &mut W) -> Result<(), ser::Error> {
 		ser_multiwrite!(
 			writer,
-			[write_u64, self.out_full.len() as u64],
-			[write_u64, self.kern_full.len() as u64],
-			[write_u64, self.kern_ids.len() as u64]
+			[write_u32, self.out_full.len() as u32],
+			[write_u32, self.kern_full.len() as u32],
+			[write_u32, self.kern_ids.len() as u32]
 		);
 
 		self.out_full.write(writer)?;

--- a/core/src/core/merkle_proof.rs
+++ b/core/src/core/merkle_proof.rs
@@ -41,7 +41,7 @@ pub struct MerkleProof {
 impl Writeable for MerkleProof {
 	fn write<W: Writer>(&self, writer: &mut W) -> Result<(), ser::Error> {
 		writer.write_u64(self.mmr_size)?;
-		writer.write_u64(self.path.len() as u64)?;
+		writer.write_u8(self.path.len() as u8)?;
 		self.path.write(writer)?;
 		Ok(())
 	}
@@ -50,7 +50,7 @@ impl Writeable for MerkleProof {
 impl Readable for MerkleProof {
 	fn read(reader: &mut dyn Reader) -> Result<MerkleProof, ser::Error> {
 		let mmr_size = reader.read_u64()?;
-		let path_len = reader.read_u64()?;
+		let path_len = reader.read_u8()?;
 		let mut path = Vec::with_capacity(path_len as usize);
 		for _ in 0..path_len {
 			let hash = Hash::read(reader)?;

--- a/core/src/core/transaction.rs
+++ b/core/src/core/transaction.rs
@@ -591,9 +591,9 @@ impl Writeable for TransactionBody {
 	fn write<W: Writer>(&self, writer: &mut W) -> Result<(), ser::Error> {
 		ser_multiwrite!(
 			writer,
-			[write_u64, self.inputs.len() as u64],
-			[write_u64, self.outputs.len() as u64],
-			[write_u64, self.kernels.len() as u64]
+			[write_u32, self.inputs.len() as u32],
+			[write_u32, self.outputs.len() as u32],
+			[write_u32, self.kernels.len() as u32]
 		);
 
 		self.inputs.write(writer)?;
@@ -609,7 +609,7 @@ impl Writeable for TransactionBody {
 impl Readable for TransactionBody {
 	fn read(reader: &mut dyn Reader) -> Result<TransactionBody, ser::Error> {
 		let (input_len, output_len, kernel_len) =
-			ser_multiread!(reader, read_u64, read_u64, read_u64);
+			ser_multiread!(reader, read_u32, read_u32, read_u32);
 
 		// Quick block weight check before proceeding.
 		// Note: We use weight_as_block here (inputs have weight).
@@ -623,9 +623,9 @@ impl Readable for TransactionBody {
 			return Err(ser::Error::TooLargeReadErr);
 		}
 
-		let inputs = read_multi(reader, input_len)?;
-		let outputs = read_multi(reader, output_len)?;
-		let kernels = read_multi(reader, kernel_len)?;
+		let inputs = read_multi(reader, input_len as u64)?;
+		let outputs = read_multi(reader, output_len as u64)?;
+		let kernels = read_multi(reader, kernel_len as u64)?;
 
 		// Initialize tx body and verify everything is sorted.
 		let body = TransactionBody::init(inputs, outputs, kernels, true)

--- a/core/src/genesis.rs
+++ b/core/src/genesis.rs
@@ -170,7 +170,7 @@ mod test {
 		);
 		assert_eq!(
 			gen_bin.hash().to_hex(),
-			"5c3d6e7c9e19dea1b48c70d11cf1bd0471fb92e1ad62dcedccd882a7d63753b0"
+			"eb9f99417c8f57600889f6bf1a1798b85cf82d8af089ec32c928001e8111a6b9"
 		);
 	}
 
@@ -186,7 +186,7 @@ mod test {
 		);
 		assert_eq!(
 			gen_bin.hash().to_hex(),
-			"a2636b7a5a739dd4da7cfefc535660ac06bbd8c60af141ee9589918610f13ef8"
+			"0c2637a6ac751ef15dea26022f45f5d2131dd2dd7210387384f5f443931be277"
 		);
 	}
 }

--- a/core/tests/block.rs
+++ b/core/tests/block.rs
@@ -265,7 +265,7 @@ fn empty_block_serialized_size() {
 	let b = new_block(vec![], &keychain, &builder, &prev, &key_id);
 	let mut vec = Vec::new();
 	ser::serialize_default(&mut vec, &b).expect("serialization failed");
-	let target_len = 441;
+	let target_len = 429;
 	assert_eq!(vec.len(), target_len);
 }
 
@@ -280,7 +280,7 @@ fn block_single_tx_serialized_size() {
 	let b = new_block(vec![&tx1], &keychain, &builder, &prev, &key_id);
 	let mut vec = Vec::new();
 	ser::serialize_default(&mut vec, &b).expect("serialization failed");
-	let target_len = 730;
+	let target_len = 718;
 	assert_eq!(vec.len(), target_len);
 }
 
@@ -295,7 +295,7 @@ fn empty_compact_block_serialized_size() {
 	let cb: CompactBlock = b.into();
 	let mut vec = Vec::new();
 	ser::serialize_default(&mut vec, &cb).expect("serialization failed");
-	let target_len = 449;
+	let target_len = 437;
 	assert_eq!(vec.len(), target_len);
 }
 
@@ -311,7 +311,7 @@ fn compact_block_single_tx_serialized_size() {
 	let cb: CompactBlock = b.into();
 	let mut vec = Vec::new();
 	ser::serialize_default(&mut vec, &cb).expect("serialization failed");
-	let target_len = 455;
+	let target_len = 443;
 	assert_eq!(vec.len(), target_len);
 }
 
@@ -331,7 +331,7 @@ fn block_10_tx_serialized_size() {
 	let b = new_block(txs.iter().collect(), &keychain, &builder, &prev, &key_id);
 	let mut vec = Vec::new();
 	ser::serialize_default(&mut vec, &b).expect("serialization failed");
-	let target_len = 3_331;
+	let target_len = 3_319;
 	assert_eq!(vec.len(), target_len,);
 }
 
@@ -352,7 +352,7 @@ fn compact_block_10_tx_serialized_size() {
 	let cb: CompactBlock = b.into();
 	let mut vec = Vec::new();
 	ser::serialize_default(&mut vec, &cb).expect("serialization failed");
-	let target_len = 509;
+	let target_len = 497;
 	assert_eq!(vec.len(), target_len,);
 }
 

--- a/core/tests/core.rs
+++ b/core/tests/core.rs
@@ -41,14 +41,14 @@ fn simple_tx_ser() {
 	let tx = tx2i1o();
 	let mut vec = Vec::new();
 	ser::serialize_default(&mut vec, &tx).expect("serialization failed");
-	let target_len = 278;
+	let target_len = 266;
 	assert_eq!(vec.len(), target_len,);
 
 	let tx = tx1i2o();
 	println!("tx = {}", serde_json::to_string_pretty(&tx).unwrap());
 	let mut vec = Vec::new();
 	ser::serialize_default(&mut vec, &tx).expect("serialization failed");
-	let target_len = 313;
+	let target_len = 301;
 	println!("tx vec = {:02x?}", vec);
 	assert_eq!(vec.len(), target_len,);
 }


### PR DESCRIPTION
clean-up some u64 sizes and replace with u32 or u8 for those vector length and so on.
1. `CompactBlockBody` 3 vector length:
```Rust
pub struct CompactBlockBody {
	/// List of full outputs - specifically the coinbase output(s)
	pub out_full: Vec<Output>,
	/// List of full kernels - specifically the coinbase kernel(s)
	pub kern_full: Vec<TxKernel>,
	/// List of transaction kernels, excluding those in the full list
	/// (short_ids)
	pub kern_ids: Vec<ShortId>,
}

```

2. `MerkleProof` path vector length:
```Rust
pub struct MerkleProof {
	/// The size of the MMR at the time the proof was created.
	pub mmr_size: u64,
	/// The sibling path from the leaf up to the final sibling hashing to the
	/// root.
	pub path: Vec<Hash>,
}
```

3. `TransactionBody` 3 vector length:
```Rust
pub struct TransactionBody {
	/// List of inputs by the transaction.
	pub inputs: Vec<InputEx>,
	/// List of outputs the transaction produces.
	pub outputs: Vec<Output>,
	/// List of kernels that make up this transaction (usually a single kernel).
	pub kernels: Vec<TxKernel>,
}
```

4. `MsgHeader` `msg_len`. This one we still use `u64` in the structure definition but use `u32` in the serialization/deserialization. At this moment, I'm not sure whether it's a good idea to directly replace this `msg_len` with `u32` type, I will check it later.

```Rust
pub struct MsgHeader {
	magic: [u8; 2],
	/// Type of the message.
	pub msg_type: Type,
	/// Total length of the message in bytes.
	pub msg_len: u64,
}
```