### PR TITLE
refact: handshake add height info

### DIFF
--- a/p2p/src/handshake.rs
+++ b/p2p/src/handshake.rs
@@ -64,6 +64,7 @@ impl Handshake {
 		&self,
 		capabilities: Capabilities,
 		total_difficulty: Difficulty,
+		height: u64,
 		self_addr: PeerAddr,
 		conn: &mut TcpStream,
 	) -> Result<PeerInfo, Error> {
@@ -83,6 +84,7 @@ impl Handshake {
 			nonce,
 			genesis: self.genesis,
 			total_difficulty,
+			height,
 			sender_addr: self_addr,
 			receiver_addr: peer_addr,
 			user_agent: USER_AGENT.to_string(),
@@ -105,7 +107,10 @@ impl Handshake {
 			user_agent: shake.user_agent,
 			addr: peer_addr,
 			version: shake.version,
-			live_info: Arc::new(RwLock::new(PeerLiveInfo::new(shake.total_difficulty))),
+			live_info: Arc::new(RwLock::new(PeerLiveInfo::new(
+				shake.total_difficulty,
+				shake.height,
+			))),
 			direction: Direction::Outbound,
 		};
 
@@ -116,8 +121,9 @@ impl Handshake {
 		}
 
 		debug!(
-			"Connected! Cumulative {} offered from {:?} {:?} {:?}",
+			"Connected! Cumulative {}@{} offered from {:?} {:?} {:?}",
 			shake.total_difficulty.to_num(),
+			shake.height,
 			peer_info.addr,
 			peer_info.user_agent,
 			peer_info.capabilities
@@ -130,6 +136,7 @@ impl Handshake {
 		&self,
 		capab: Capabilities,
 		total_difficulty: Difficulty,
+		height: u64,
 		conn: &mut TcpStream,
 	) -> Result<PeerInfo, Error> {
 		// Note: We read the Hand message *before* we know which protocol version
@@ -165,7 +172,10 @@ impl Handshake {
 			user_agent: hand.user_agent,
 			addr: resolve_peer_addr(hand.sender_addr, &conn),
 			version: hand.version,
-			live_info: Arc::new(RwLock::new(PeerLiveInfo::new(hand.total_difficulty))),
+			live_info: Arc::new(RwLock::new(PeerLiveInfo::new(
+				hand.total_difficulty,
+				hand.height,
+			))),
 			direction: Direction::Inbound,
 		};
 
@@ -182,7 +192,8 @@ impl Handshake {
 			version,
 			capabilities: capab,
 			genesis: self.genesis,
-			total_difficulty: total_difficulty,
+			total_difficulty,
+			height,
 			user_agent: USER_AGENT.to_string(),
 		};
 

--- a/p2p/src/msg.rs
+++ b/p2p/src/msg.rs
@@ -327,6 +327,8 @@ pub struct Hand {
 	/// total difficulty accumulated by the sender, used to check whether sync
 	/// may be needed
 	pub total_difficulty: Difficulty,
+	/// total height
+	pub height: u64,
 	/// network address of the sender
 	pub sender_addr: PeerAddr,
 	/// network address of the receiver
@@ -344,6 +346,7 @@ impl Writeable for Hand {
 			[write_u64, self.nonce]
 		);
 		self.total_difficulty.write(writer)?;
+		writer.write_u64(self.height)?;
 		self.sender_addr.write(writer)?;
 		self.receiver_addr.write(writer)?;
 		writer.write_bytes(&self.user_agent)?;
@@ -358,6 +361,7 @@ impl Readable for Hand {
 		let (capab, nonce) = ser_multiread!(reader, read_u32, read_u64);
 		let capabilities = Capabilities::from_bits_truncate(capab);
 		let total_difficulty = Difficulty::read(reader)?;
+		let height = reader.read_u64()?;
 		let sender_addr = PeerAddr::read(reader)?;
 		let receiver_addr = PeerAddr::read(reader)?;
 		let ua = reader.read_bytes_len_prefix()?;
@@ -369,6 +373,7 @@ impl Readable for Hand {
 			nonce,
 			genesis,
 			total_difficulty,
+			height,
 			sender_addr,
 			receiver_addr,
 			user_agent,
@@ -388,6 +393,8 @@ pub struct Shake {
 	/// total difficulty accumulated by the sender, used to check whether sync
 	/// may be needed
 	pub total_difficulty: Difficulty,
+	/// total height
+	pub height: u64,
 	/// name of version of the software
 	pub user_agent: String,
 }
@@ -397,6 +404,7 @@ impl Writeable for Shake {
 		self.version.write(writer)?;
 		writer.write_u32(self.capabilities.bits())?;
 		self.total_difficulty.write(writer)?;
+		writer.write_u64(self.height)?;
 		writer.write_bytes(&self.user_agent)?;
 		self.genesis.write(writer)?;
 		Ok(())
@@ -409,6 +417,7 @@ impl Readable for Shake {
 		let capab = reader.read_u32()?;
 		let capabilities = Capabilities::from_bits_truncate(capab);
 		let total_difficulty = Difficulty::read(reader)?;
+		let height = reader.read_u64()?;
 		let ua = reader.read_bytes_len_prefix()?;
 		let user_agent = String::from_utf8(ua).map_err(|_| ser::Error::CorruptedData)?;
 		let genesis = Hash::read(reader)?;
@@ -417,6 +426,7 @@ impl Readable for Shake {
 			capabilities,
 			genesis,
 			total_difficulty,
+			height,
 			user_agent,
 		})
 	}

--- a/p2p/src/peer.rs
+++ b/p2p/src/peer.rs
@@ -102,11 +102,12 @@ impl Peer {
 		mut conn: TcpStream,
 		capab: Capabilities,
 		total_difficulty: Difficulty,
+		height: u64,
 		hs: &Handshake,
 		adapter: Arc<dyn NetAdapter>,
 	) -> Result<Peer, Error> {
 		debug!("accept: handshaking from {:?}", conn.peer_addr());
-		let info = hs.accept(capab, total_difficulty, &mut conn);
+		let info = hs.accept(capab, total_difficulty, height, &mut conn);
 		match info {
 			Ok(info) => Ok(Peer::new(info, conn, adapter)?),
 			Err(e) => {
@@ -127,12 +128,13 @@ impl Peer {
 		mut conn: TcpStream,
 		capab: Capabilities,
 		total_difficulty: Difficulty,
+		height: u64,
 		self_addr: PeerAddr,
 		hs: &Handshake,
 		adapter: Arc<dyn NetAdapter>,
 	) -> Result<Peer, Error> {
 		debug!("connect: handshaking with {:?}", conn.peer_addr());
-		let info = hs.initiate(capab, total_difficulty, self_addr, &mut conn);
+		let info = hs.initiate(capab, total_difficulty, height, self_addr, &mut conn);
 		match info {
 			Ok(info) => Ok(Peer::new(info, conn, adapter)?),
 			Err(e) => {

--- a/p2p/src/serv.rs
+++ b/p2p/src/serv.rs
@@ -155,11 +155,13 @@ impl Server {
 			Ok(stream) => {
 				let addr = SocketAddr::new(self.config.host, self.config.port);
 				let total_diff = self.peers.total_difficulty()?;
+				let height = self.peers.total_height()?;
 
 				let peer = Peer::connect(
 					stream,
 					self.capabilities,
 					total_diff,
+					height,
 					PeerAddr(addr),
 					&self.handshake,
 					self.peers.clone(),
@@ -186,12 +188,14 @@ impl Server {
 			return Err(Error::ConnectionClose);
 		}
 		let total_diff = self.peers.total_difficulty()?;
+		let height = self.peers.total_height()?;
 
 		// accept the peer and add it to the server map
 		let peer = Peer::accept(
 			stream,
 			self.capabilities,
 			total_diff,
+			height,
 			&self.handshake,
 			self.peers.clone(),
 		)?;

--- a/p2p/src/types.rs
+++ b/p2p/src/types.rs
@@ -407,10 +407,10 @@ pub struct PeerInfo {
 }
 
 impl PeerLiveInfo {
-	pub fn new(difficulty: Difficulty) -> PeerLiveInfo {
+	pub fn new(difficulty: Difficulty, height: u64) -> PeerLiveInfo {
 		PeerLiveInfo {
 			total_difficulty: difficulty,
-			height: 0,
+			height,
 			first_seen: Utc::now(),
 			last_seen: Utc::now(),
 			stuck_detector: Utc::now(),

--- a/p2p/tests/peer_handshake.rs
+++ b/p2p/tests/peer_handshake.rs
@@ -75,6 +75,7 @@ fn peer_handshake() {
 		socket,
 		p2p::Capabilities::UNKNOWN,
 		Difficulty::min(),
+		0,
 		my_addr,
 		&p2p::handshake::Handshake::new(Hash::from_vec(&vec![]), p2p_config.clone()),
 		net_adapter,


### PR DESCRIPTION
```sh
	/// total difficulty accumulated by the sender, used to check whether sync may be needed
	pub total_difficulty: Difficulty,
	/// height
	pub height: u64,
```
No need to wait 10 seconds for the `Ping/Pong` messages to get the `height` info. The `height` info should be put into the first message which peers communicate, i.e., both the `Hand` and `Shake` message.
