### PR TITLE
InputEx signature verification when spend SigLocked output

### DIFF
--- a/api/src/handlers/chain_api.rs
+++ b/api/src/handlers/chain_api.rs
@@ -1,4 +1,4 @@
-// Copyright 2018 The Grin Developers
+	// Copyright 2018 The Grin Developers
 // Modifications Copyright 2019 The Gotts Developers
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/handlers/chain_api.rs
+++ b/api/src/handlers/chain_api.rs
@@ -1,4 +1,4 @@
-	// Copyright 2018 The Grin Developers
+// Copyright 2018 The Grin Developers
 // Modifications Copyright 2019 The Gotts Developers
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -20,8 +20,8 @@ use crate::core::core::hash::{Hash, Hashed, ZERO_HASH};
 use crate::core::core::merkle_proof::MerkleProof;
 use crate::core::core::verifier_cache::VerifierCache;
 use crate::core::core::{
-	Block, BlockHeader, BlockSums, Committed, Input, Output, OutputEx, OutputFeatures, OutputI, OutputIdentifier,
-	Transaction, TxKernel, TxKernelApiEntry,
+	Block, BlockHeader, BlockSums, Committed, Input, Output, OutputEx, OutputFeatures, OutputI,
+	OutputIdentifier, Transaction, TxKernel, TxKernelApiEntry,
 };
 use crate::core::global;
 use crate::core::pow;
@@ -525,7 +525,10 @@ impl Chain {
 	}
 
 	/// Find the complete input/s info, use chain database data according to inputs
-	pub fn get_complete_inputs(&self, inputs: &Vec<Input>) -> Result<HashMap<Commitment, OutputEx>, Error> {
+	pub fn get_complete_inputs(
+		&self,
+		inputs: &Vec<Input>,
+	) -> Result<HashMap<Commitment, OutputEx>, Error> {
 		let header_pmmr = self.header_pmmr.read();
 		let txhashset = self.txhashset.read();
 		let complete_inputs = txhashset::utxo_view(&header_pmmr, &txhashset, |utxo| {

--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -20,7 +20,7 @@ use crate::core::core::hash::{Hash, Hashed, ZERO_HASH};
 use crate::core::core::merkle_proof::MerkleProof;
 use crate::core::core::verifier_cache::VerifierCache;
 use crate::core::core::{
-	Block, BlockHeader, BlockSums, Committed, Output, OutputFeatures, OutputI, OutputIdentifier,
+	Block, BlockHeader, BlockSums, Committed, Input, Output, OutputEx, OutputFeatures, OutputI, OutputIdentifier,
 	Transaction, TxKernel, TxKernelApiEntry,
 };
 use crate::core::global;
@@ -522,6 +522,16 @@ impl Chain {
 	fn next_block_height(&self) -> Result<u64, Error> {
 		let bh = self.head_header()?;
 		Ok(bh.height + 1)
+	}
+
+	/// Find the complete input/s info, use chain database data according to inputs
+	pub fn get_complete_inputs(&self, inputs: &Vec<Input>) -> Result<HashMap<Commitment, OutputEx>, Error> {
+		let header_pmmr = self.header_pmmr.read();
+		let txhashset = self.txhashset.read();
+		let complete_inputs = txhashset::utxo_view(&header_pmmr, &txhashset, |utxo| {
+			Ok(utxo.get_complete_inputs(inputs)?)
+		})?;
+		Ok(complete_inputs)
 	}
 
 	/// Verify we are not attempting to spend a coinbase output

--- a/chain/src/error.rs
+++ b/chain/src/error.rs
@@ -109,7 +109,7 @@ pub enum ErrorKind {
 	#[fail(display = "Block sum mismatch")]
 	BlockSumMismatch,
 	/// Transaction public value sums do not match.
-	#[fail(display = "Transaction sum mismatch")]
+	#[fail(display = "Transaction input/output value sum mismatch")]
 	TransactionSumMismatch,
 	/// Invalid block version, either a mistake or outdated software
 	#[fail(display = "Invalid Block Version: {:?}", _0)]

--- a/chain/src/pipe.rs
+++ b/chain/src/pipe.rs
@@ -412,7 +412,9 @@ fn validate_block(
 ) -> Result<(), Error> {
 	let ref mut extension = ext.extension;
 	let ref mut header_extension = ext.header_extension;
-	let complete_inputs = extension.utxo_view(header_extension).get_complete_inputs(&block.inputs())?;
+	let complete_inputs = extension
+		.utxo_view(header_extension)
+		.get_complete_inputs(&block.inputs())?;
 
 	block
 		.validate(verifier_cache, &complete_inputs)

--- a/chain/src/txhashset/utxo_view.rs
+++ b/chain/src/txhashset/utxo_view.rs
@@ -18,13 +18,15 @@
 use crate::core::core::hash::{Hash, Hashed};
 use crate::core::core::pmmr::{self, ReadonlyPMMR};
 use crate::core::core::{
-	Block, BlockHeader, Input, Output, OutputFeatures, OutputI, OutputII, Transaction,
+	Block, BlockHeader, Input, Output, OutputEx, OutputFeatures, OutputI, OutputII, Transaction,
 };
 use crate::core::global;
 use crate::core::ser::PMMRIndexHashable;
 use crate::error::{Error, ErrorKind};
 use crate::store::Batch;
+use crate::util::secp::pedersen::Commitment;
 use gotts_store::pmmr::PMMRBackend;
+use std::collections::HashMap;
 
 /// Readonly view of the UTXO set (based on output MMR).
 pub struct UTXOView<'a> {
@@ -183,6 +185,30 @@ impl<'a> UTXOView<'a> {
 			}
 		}
 		Ok(())
+	}
+
+	/// Find the complete input/s info, use chain database data according to inputs
+	pub fn get_complete_inputs(&self, inputs: &Vec<Input>) -> Result<HashMap<Commitment, OutputEx>, Error> {
+		let mut complete_inputs: HashMap<Commitment, OutputEx> = HashMap::new();
+		for input in inputs {
+			if let Ok(ofph) = self.batch.get_output_pos_height(&input.commitment()) {
+				let output = match ofph.features {
+					OutputFeatures::Plain | OutputFeatures::Coinbase => self.output_i_pmmr.get_data(ofph.position).unwrap().into_output(),
+					OutputFeatures::SigLocked => self.output_ii_pmmr.get_data(ofph.position).unwrap().into_output(),
+				};
+				if output.id().commitment() == input.commitment() {
+					complete_inputs.insert(
+						input.commitment().clone(),
+						OutputEx {
+							output,
+							height: ofph.height,
+							mmr_index: ofph.position,
+						}
+					);
+				}
+			}
+		}
+		Ok(complete_inputs)
 	}
 
 	/// Verify we are not attempting to spend any coinbase outputs

--- a/chain/src/txhashset/utxo_view.rs
+++ b/chain/src/txhashset/utxo_view.rs
@@ -188,13 +188,24 @@ impl<'a> UTXOView<'a> {
 	}
 
 	/// Find the complete input/s info, use chain database data according to inputs
-	pub fn get_complete_inputs(&self, inputs: &Vec<Input>) -> Result<HashMap<Commitment, OutputEx>, Error> {
+	pub fn get_complete_inputs(
+		&self,
+		inputs: &Vec<Input>,
+	) -> Result<HashMap<Commitment, OutputEx>, Error> {
 		let mut complete_inputs: HashMap<Commitment, OutputEx> = HashMap::new();
 		for input in inputs {
 			if let Ok(ofph) = self.batch.get_output_pos_height(&input.commitment()) {
 				let output = match ofph.features {
-					OutputFeatures::Plain | OutputFeatures::Coinbase => self.output_i_pmmr.get_data(ofph.position).unwrap().into_output(),
-					OutputFeatures::SigLocked => self.output_ii_pmmr.get_data(ofph.position).unwrap().into_output(),
+					OutputFeatures::Plain | OutputFeatures::Coinbase => self
+						.output_i_pmmr
+						.get_data(ofph.position)
+						.unwrap()
+						.into_output(),
+					OutputFeatures::SigLocked => self
+						.output_ii_pmmr
+						.get_data(ofph.position)
+						.unwrap()
+						.into_output(),
 				};
 				if output.id().commitment() == input.commitment() {
 					complete_inputs.insert(
@@ -203,7 +214,7 @@ impl<'a> UTXOView<'a> {
 							output,
 							height: ofph.height,
 							mmr_index: ofph.position,
-						}
+						},
 					);
 				}
 			}

--- a/chain/tests/test_coinbase_maturity.rs
+++ b/chain/tests/test_coinbase_maturity.rs
@@ -48,7 +48,7 @@ fn test_coinbase_maturity() {
 
 	{
 		let chain = chain::Chain::init(
-			".gotts".to_string(),
+			chain_dir.to_string(),
 			Arc::new(NoopAdapter {}),
 			genesis_block,
 			pow::verify_size,

--- a/core/src/core/block.rs
+++ b/core/src/core/block.rs
@@ -18,7 +18,7 @@
 use crate::util::RwLock;
 use chrono::naive::{MAX_DATE, MIN_DATE};
 use chrono::prelude::{DateTime, NaiveDateTime, Utc};
-use std::collections::{HashSet, HashMap};
+use std::collections::{HashMap, HashSet};
 use std::fmt;
 use std::iter::FromIterator;
 use std::sync::Arc;
@@ -29,8 +29,8 @@ use crate::core::compact_block::{CompactBlock, CompactBlockBody};
 use crate::core::hash::{DefaultHashable, Hash, Hashed, ZERO_HASH};
 use crate::core::verifier_cache::VerifierCache;
 use crate::core::{
-	transaction, Commitment, Input, InputEx, KernelFeatures, Output, OutputEx, Transaction, TransactionBody,
-	TxKernel, Weighting,
+	transaction, Commitment, Input, InputEx, KernelFeatures, Output, OutputEx, Transaction,
+	TransactionBody, TxKernel, Weighting,
 };
 
 use crate::global;
@@ -683,8 +683,17 @@ impl Block {
 	/// Validates all the elements in a block that can be checked without
 	/// additional data. Includes commitment sums and kernels, Merkle
 	/// trees, reward, etc.
-	pub fn validate(&self, verifier: Arc<RwLock<dyn VerifierCache>>, complete_inputs: &HashMap<Commitment, OutputEx>) -> Result<Commitment, Error> {
-		self.body.validate(Weighting::AsBlock, verifier, complete_inputs, self.header.height)?;
+	pub fn validate(
+		&self,
+		verifier: Arc<RwLock<dyn VerifierCache>>,
+		complete_inputs: &HashMap<Commitment, OutputEx>,
+	) -> Result<Commitment, Error> {
+		self.body.validate(
+			Weighting::AsBlock,
+			verifier,
+			complete_inputs,
+			self.header.height,
+		)?;
 
 		self.verify_kernel_lock_heights()?;
 		self.verify_coinbase()?;

--- a/core/src/core/transaction.rs
+++ b/core/src/core/transaction.rs
@@ -193,8 +193,10 @@ pub enum Error {
 	InvalidKernelFeatures,
 	/// Validation error relating to input signature message.
 	InvalidInputSigMsg,
-	/// Signature verification error.
+	/// TxKernel Signature verification error.
 	IncorrectSignature,
+	/// InputUnlocker Signature verification error.
+	UnlockerIncorrectSignature,
 	/// Signature verification error, public key hash not match.
 	IncorrectPubkey,
 	/// Input does not exist among UTXO sets.
@@ -945,7 +947,7 @@ impl TransactionBody {
 			let secp = secp.lock();
 
 			if !secp::aggsig::verify_batch(&secp, &sigs, &msgs, &pubkeys) {
-				return Err(Error::IncorrectSignature);
+				return Err(Error::UnlockerIncorrectSignature);
 			}
 		}
 

--- a/core/src/core/verifier_cache.rs
+++ b/core/src/core/verifier_cache.rs
@@ -19,25 +19,29 @@
 use lru_cache::LruCache;
 
 use crate::core::hash::{Hash, Hashed};
-use crate::core::TxKernel;
+use crate::core::{InputEx, TxKernel};
 
 /// Verifier cache for caching expensive verification results.
 /// Specifically the following -
 ///   * kernel signature verification
-///   * output rangeproof verification
+///   * InputUnlocker signature verification
 pub trait VerifierCache: Sync + Send {
-	/// Takes a vec of tx kernels and returns those kernels
-	/// that have not yet been verified.
+	/// Takes a vec of tx kernels and returns those kernels that have not yet been verified.
 	fn filter_kernel_sig_unverified(&mut self, kernels: &[TxKernel]) -> Vec<TxKernel>;
 	/// Adds a vec of tx kernels to the cache (used in conjunction with the the filter above).
 	fn add_kernel_sig_verified(&mut self, kernels: Vec<TxKernel>);
+	/// Takes a vec of InputEx and returns those InputEx that have not yet been verified.
+	fn filter_unlocker_unverified(&mut self, inputs: &[InputEx]) -> Vec<InputEx>;
+	/// Adds a vec of InputEx to the cache (used in conjunction with the the filter above).
+	fn add_unlocker_verified(&mut self, inputs: Vec<InputEx>);
 }
 
 /// An implementation of verifier_cache using lru_cache.
 /// Caches tx kernels by kernel hash.
-/// Caches outputs by output rangeproof hash (rangeproofs are committed to separately).
+/// Caches InputUnlocker by InputUnlocker hash (InputUnlocker are committed to separately).
 pub struct LruVerifierCache {
 	kernel_sig_verification_cache: LruCache<Hash, ()>,
+	unlocker_verification_cache: LruCache<Hash, ()>,
 }
 
 impl LruVerifierCache {
@@ -46,6 +50,7 @@ impl LruVerifierCache {
 	pub fn new() -> LruVerifierCache {
 		LruVerifierCache {
 			kernel_sig_verification_cache: LruCache::new(50_000),
+			unlocker_verification_cache: LruCache::new(50_000),
 		}
 	}
 }
@@ -68,6 +73,26 @@ impl VerifierCache for LruVerifierCache {
 	fn add_kernel_sig_verified(&mut self, kernels: Vec<TxKernel>) {
 		for k in kernels {
 			self.kernel_sig_verification_cache.insert(k.hash(), ());
+		}
+	}
+
+	fn filter_unlocker_unverified(&mut self, inputs: &[InputEx]) -> Vec<InputEx> {
+		let res = inputs
+			.iter()
+			.filter(|x| !self.unlocker_verification_cache.contains_key(&x.hash()))
+			.cloned()
+			.collect::<Vec<_>>();
+		trace!(
+			"lru_verifier_cache: InputEx: {}, not cached (must verify): {}",
+			inputs.len(),
+			res.len()
+		);
+		res
+	}
+
+	fn add_unlocker_verified(&mut self, inputs: Vec<InputEx>) {
+		for i in inputs {
+			self.unlocker_verification_cache.insert(i.hash(), ());
 		}
 	}
 }

--- a/core/src/libtx/build.rs
+++ b/core/src/libtx/build.rs
@@ -441,7 +441,7 @@ mod test {
 		)
 		.unwrap();
 
-		tx.validate(Weighting::AsTransaction, vc.clone()).unwrap();
+		tx.validate(Weighting::AsTransaction, vc.clone(), 0).unwrap();
 	}
 
 	#[test]
@@ -466,7 +466,7 @@ mod test {
 		)
 		.unwrap();
 
-		tx.validate(Weighting::AsTransaction, vc.clone()).unwrap();
+		tx.validate(Weighting::AsTransaction, vc.clone(), 0).unwrap();
 	}
 
 	#[test]
@@ -489,6 +489,6 @@ mod test {
 		)
 		.unwrap();
 
-		tx.validate(Weighting::AsTransaction, vc.clone()).unwrap();
+		tx.validate(Weighting::AsTransaction, vc.clone(), 0).unwrap();
 	}
 }

--- a/core/src/libtx/build.rs
+++ b/core/src/libtx/build.rs
@@ -441,7 +441,8 @@ mod test {
 		)
 		.unwrap();
 
-		tx.validate(Weighting::AsTransaction, vc.clone(), 0).unwrap();
+		tx.validate(Weighting::AsTransaction, vc.clone(), 0)
+			.unwrap();
 	}
 
 	#[test]
@@ -466,7 +467,8 @@ mod test {
 		)
 		.unwrap();
 
-		tx.validate(Weighting::AsTransaction, vc.clone(), 0).unwrap();
+		tx.validate(Weighting::AsTransaction, vc.clone(), 0)
+			.unwrap();
 	}
 
 	#[test]
@@ -489,6 +491,7 @@ mod test {
 		)
 		.unwrap();
 
-		tx.validate(Weighting::AsTransaction, vc.clone(), 0).unwrap();
+		tx.validate(Weighting::AsTransaction, vc.clone(), 0)
+			.unwrap();
 	}
 }

--- a/core/tests/block.rs
+++ b/core/tests/block.rs
@@ -35,8 +35,8 @@ use gotts_core as core;
 use gotts_core::global::ChainTypes;
 use gotts_keychain as keychain;
 use gotts_util as util;
-use std::sync::Arc;
 use std::collections::HashMap;
+use std::sync::Arc;
 
 fn verifier_cache() -> Arc<RwLock<dyn VerifierCache>> {
 	Arc::new(RwLock::new(LruVerifierCache::new()))

--- a/core/tests/block.rs
+++ b/core/tests/block.rs
@@ -36,6 +36,7 @@ use gotts_core::global::ChainTypes;
 use gotts_keychain as keychain;
 use gotts_util as util;
 use std::sync::Arc;
+use std::collections::HashMap;
 
 fn verifier_cache() -> Arc<RwLock<dyn VerifierCache>> {
 	Arc::new(RwLock::new(LruVerifierCache::new()))
@@ -67,7 +68,8 @@ fn too_large_block() {
 	let prev = BlockHeader::default();
 	let key_id = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
 	let b = new_block(vec![&tx], &keychain, &builder, &prev, &key_id);
-	assert!(b.validate(verifier_cache()).is_err());
+	let complete_inputs = HashMap::new();
+	assert!(b.validate(verifier_cache(), &complete_inputs).is_err());
 }
 
 #[test]
@@ -113,9 +115,9 @@ fn block_with_cut_through() {
 		&key_id,
 	);
 
-	// block should have been automatically compacted (including reward
-	// output) and should still be valid
-	b.validate(verifier_cache()).unwrap();
+	// block should have been automatically compacted (including reward output) and should still be valid
+	let complete_inputs = HashMap::new();
+	b.validate(verifier_cache(), &complete_inputs).unwrap();
 	assert_eq!(b.inputs().len(), 3);
 	assert_eq!(b.outputs().len(), 3);
 }
@@ -148,9 +150,9 @@ fn empty_block_with_coinbase_is_valid() {
 		.collect::<Vec<_>>();
 	assert_eq!(coinbase_kernels.len(), 1);
 
-	// the block should be valid here (single coinbase output with corresponding
-	// txn kernel)
-	assert!(b.validate(verifier_cache()).is_ok());
+	// the block should be valid here (single coinbase output with corresponding txn kernel)
+	let complete_inputs = HashMap::new();
+	assert!(b.validate(verifier_cache(), &complete_inputs).is_ok());
 }
 
 #[test]
@@ -171,8 +173,9 @@ fn remove_coinbase_output_flag() {
 
 	assert_eq!(b.verify_coinbase(), Err(Error::CoinbaseSumMismatch));
 	assert!(b.verify_kernel_sums().is_ok());
+	let complete_inputs = HashMap::new();
 	assert_eq!(
-		b.validate(verifier_cache()),
+		b.validate(verifier_cache(), &complete_inputs),
 		Err(Error::CoinbaseSumMismatch)
 	);
 }
@@ -195,8 +198,9 @@ fn remove_coinbase_kernel_flag() {
 
 	// Also results in the block no longer validating correctly
 	// because the message being signed on each tx kernel includes the kernel features.
+	let complete_inputs = HashMap::new();
 	assert_eq!(
-		b.validate(verifier_cache()),
+		b.validate(verifier_cache(), &complete_inputs),
 		Err(Error::Transaction(transaction::Error::IncorrectSignature))
 	);
 }

--- a/core/tests/core.rs
+++ b/core/tests/core.rs
@@ -35,6 +35,7 @@ use gotts_keychain as keychain;
 use gotts_util as util;
 use serde_json;
 use std::sync::Arc;
+use std::collections::HashMap;
 
 #[test]
 fn simple_tx_ser() {
@@ -126,7 +127,7 @@ fn build_tx_kernel() {
 	.unwrap();
 
 	// check the tx is valid
-	tx.validate(Weighting::AsTransaction, verifier_cache())
+	tx.validate(Weighting::AsTransaction, verifier_cache(), 0)
 		.unwrap();
 
 	// check the kernel is also itself valid
@@ -146,10 +147,10 @@ fn transaction_cut_through() {
 	let tx2 = tx2i1o();
 
 	assert!(tx1
-		.validate(Weighting::AsTransaction, verifier_cache())
+		.validate(Weighting::AsTransaction, verifier_cache(), 0)
 		.is_ok());
 	assert!(tx2
-		.validate(Weighting::AsTransaction, verifier_cache())
+		.validate(Weighting::AsTransaction, verifier_cache(), 0)
 		.is_ok());
 
 	let vc = verifier_cache();
@@ -157,7 +158,7 @@ fn transaction_cut_through() {
 	// now build a "cut_through" tx from tx1 and tx2
 	let tx3 = aggregate(vec![tx1, tx2]).unwrap();
 
-	assert!(tx3.validate(Weighting::AsTransaction, vc.clone()).is_ok());
+	assert!(tx3.validate(Weighting::AsTransaction, vc.clone(), 0).is_ok());
 }
 
 // Attempt to deaggregate a multi-kernel transaction in a different way
@@ -170,31 +171,31 @@ fn multi_kernel_transaction_deaggregation() {
 
 	let vc = verifier_cache();
 
-	assert!(tx1.validate(Weighting::AsTransaction, vc.clone()).is_ok());
-	assert!(tx2.validate(Weighting::AsTransaction, vc.clone()).is_ok());
-	assert!(tx3.validate(Weighting::AsTransaction, vc.clone()).is_ok());
-	assert!(tx4.validate(Weighting::AsTransaction, vc.clone()).is_ok());
+	assert!(tx1.validate(Weighting::AsTransaction, vc.clone(), 0).is_ok());
+	assert!(tx2.validate(Weighting::AsTransaction, vc.clone(), 0).is_ok());
+	assert!(tx3.validate(Weighting::AsTransaction, vc.clone(), 0).is_ok());
+	assert!(tx4.validate(Weighting::AsTransaction, vc.clone(), 0).is_ok());
 
 	let tx1234 = aggregate(vec![tx1.clone(), tx2.clone(), tx3.clone(), tx4.clone()]).unwrap();
 	let tx12 = aggregate(vec![tx1.clone(), tx2.clone()]).unwrap();
 	let tx34 = aggregate(vec![tx3.clone(), tx4.clone()]).unwrap();
 
 	assert!(tx1234
-		.validate(Weighting::AsTransaction, vc.clone())
+		.validate(Weighting::AsTransaction, vc.clone(), 0)
 		.is_ok());
-	assert!(tx12.validate(Weighting::AsTransaction, vc.clone()).is_ok());
-	assert!(tx34.validate(Weighting::AsTransaction, vc.clone()).is_ok());
+	assert!(tx12.validate(Weighting::AsTransaction, vc.clone(), 0).is_ok());
+	assert!(tx34.validate(Weighting::AsTransaction, vc.clone(), 0).is_ok());
 
 	let deaggregated_tx34 = deaggregate(tx1234.clone(), vec![tx12.clone()]).unwrap();
 	assert!(deaggregated_tx34
-		.validate(Weighting::AsTransaction, vc.clone())
+		.validate(Weighting::AsTransaction, vc.clone(), 0)
 		.is_ok());
 	assert_eq!(tx34, deaggregated_tx34);
 
 	let deaggregated_tx12 = deaggregate(tx1234.clone(), vec![tx34.clone()]).unwrap();
 
 	assert!(deaggregated_tx12
-		.validate(Weighting::AsTransaction, vc.clone())
+		.validate(Weighting::AsTransaction, vc.clone(), 0)
 		.is_ok());
 	assert_eq!(tx12, deaggregated_tx12);
 }
@@ -207,19 +208,19 @@ fn multi_kernel_transaction_deaggregation_2() {
 
 	let vc = verifier_cache();
 
-	assert!(tx1.validate(Weighting::AsTransaction, vc.clone()).is_ok());
-	assert!(tx2.validate(Weighting::AsTransaction, vc.clone()).is_ok());
-	assert!(tx3.validate(Weighting::AsTransaction, vc.clone()).is_ok());
+	assert!(tx1.validate(Weighting::AsTransaction, vc.clone(), 0).is_ok());
+	assert!(tx2.validate(Weighting::AsTransaction, vc.clone(), 0).is_ok());
+	assert!(tx3.validate(Weighting::AsTransaction, vc.clone(), 0).is_ok());
 
 	let tx123 = aggregate(vec![tx1.clone(), tx2.clone(), tx3.clone()]).unwrap();
 	let tx12 = aggregate(vec![tx1.clone(), tx2.clone()]).unwrap();
 
-	assert!(tx123.validate(Weighting::AsTransaction, vc.clone()).is_ok());
-	assert!(tx12.validate(Weighting::AsTransaction, vc.clone()).is_ok());
+	assert!(tx123.validate(Weighting::AsTransaction, vc.clone(), 0).is_ok());
+	assert!(tx12.validate(Weighting::AsTransaction, vc.clone(), 0).is_ok());
 
 	let deaggregated_tx3 = deaggregate(tx123.clone(), vec![tx12.clone()]).unwrap();
 	assert!(deaggregated_tx3
-		.validate(Weighting::AsTransaction, vc.clone())
+		.validate(Weighting::AsTransaction, vc.clone(), 0)
 		.is_ok());
 	assert_eq!(tx3, deaggregated_tx3);
 }
@@ -232,20 +233,20 @@ fn multi_kernel_transaction_deaggregation_3() {
 
 	let vc = verifier_cache();
 
-	assert!(tx1.validate(Weighting::AsTransaction, vc.clone()).is_ok());
-	assert!(tx2.validate(Weighting::AsTransaction, vc.clone()).is_ok());
-	assert!(tx3.validate(Weighting::AsTransaction, vc.clone()).is_ok());
+	assert!(tx1.validate(Weighting::AsTransaction, vc.clone(), 0).is_ok());
+	assert!(tx2.validate(Weighting::AsTransaction, vc.clone(), 0).is_ok());
+	assert!(tx3.validate(Weighting::AsTransaction, vc.clone(), 0).is_ok());
 
 	let tx123 = aggregate(vec![tx1.clone(), tx2.clone(), tx3.clone()]).unwrap();
 	let tx13 = aggregate(vec![tx1.clone(), tx3.clone()]).unwrap();
 	let tx2 = aggregate(vec![tx2.clone()]).unwrap();
 
-	assert!(tx123.validate(Weighting::AsTransaction, vc.clone()).is_ok());
-	assert!(tx2.validate(Weighting::AsTransaction, vc.clone()).is_ok());
+	assert!(tx123.validate(Weighting::AsTransaction, vc.clone(), 0).is_ok());
+	assert!(tx2.validate(Weighting::AsTransaction, vc.clone(), 0).is_ok());
 
 	let deaggregated_tx13 = deaggregate(tx123.clone(), vec![tx2.clone()]).unwrap();
 	assert!(deaggregated_tx13
-		.validate(Weighting::AsTransaction, vc.clone())
+		.validate(Weighting::AsTransaction, vc.clone(), 0)
 		.is_ok());
 	assert_eq!(tx13, deaggregated_tx13);
 }
@@ -260,11 +261,11 @@ fn multi_kernel_transaction_deaggregation_4() {
 
 	let vc = verifier_cache();
 
-	assert!(tx1.validate(Weighting::AsTransaction, vc.clone()).is_ok());
-	assert!(tx2.validate(Weighting::AsTransaction, vc.clone()).is_ok());
-	assert!(tx3.validate(Weighting::AsTransaction, vc.clone()).is_ok());
-	assert!(tx4.validate(Weighting::AsTransaction, vc.clone()).is_ok());
-	assert!(tx5.validate(Weighting::AsTransaction, vc.clone()).is_ok());
+	assert!(tx1.validate(Weighting::AsTransaction, vc.clone(), 0).is_ok());
+	assert!(tx2.validate(Weighting::AsTransaction, vc.clone(), 0).is_ok());
+	assert!(tx3.validate(Weighting::AsTransaction, vc.clone(), 0).is_ok());
+	assert!(tx4.validate(Weighting::AsTransaction, vc.clone(), 0).is_ok());
+	assert!(tx5.validate(Weighting::AsTransaction, vc.clone(), 0).is_ok());
 
 	let tx12345 = aggregate(vec![
 		tx1.clone(),
@@ -275,7 +276,7 @@ fn multi_kernel_transaction_deaggregation_4() {
 	])
 	.unwrap();
 	assert!(tx12345
-		.validate(Weighting::AsTransaction, vc.clone())
+		.validate(Weighting::AsTransaction, vc.clone(), 0)
 		.is_ok());
 
 	let deaggregated_tx5 = deaggregate(
@@ -284,7 +285,7 @@ fn multi_kernel_transaction_deaggregation_4() {
 	)
 	.unwrap();
 	assert!(deaggregated_tx5
-		.validate(Weighting::AsTransaction, vc.clone())
+		.validate(Weighting::AsTransaction, vc.clone(), 0)
 		.is_ok());
 	assert_eq!(tx5, deaggregated_tx5);
 }
@@ -299,11 +300,11 @@ fn multi_kernel_transaction_deaggregation_5() {
 
 	let vc = verifier_cache();
 
-	assert!(tx1.validate(Weighting::AsTransaction, vc.clone()).is_ok());
-	assert!(tx2.validate(Weighting::AsTransaction, vc.clone()).is_ok());
-	assert!(tx3.validate(Weighting::AsTransaction, vc.clone()).is_ok());
-	assert!(tx4.validate(Weighting::AsTransaction, vc.clone()).is_ok());
-	assert!(tx5.validate(Weighting::AsTransaction, vc.clone()).is_ok());
+	assert!(tx1.validate(Weighting::AsTransaction, vc.clone(), 0).is_ok());
+	assert!(tx2.validate(Weighting::AsTransaction, vc.clone(), 0).is_ok());
+	assert!(tx3.validate(Weighting::AsTransaction, vc.clone(), 0).is_ok());
+	assert!(tx4.validate(Weighting::AsTransaction, vc.clone(), 0).is_ok());
+	assert!(tx5.validate(Weighting::AsTransaction, vc.clone(), 0).is_ok());
 
 	let tx12345 = aggregate(vec![
 		tx1.clone(),
@@ -317,12 +318,12 @@ fn multi_kernel_transaction_deaggregation_5() {
 	let tx34 = aggregate(vec![tx3.clone(), tx4.clone()]).unwrap();
 
 	assert!(tx12345
-		.validate(Weighting::AsTransaction, vc.clone())
+		.validate(Weighting::AsTransaction, vc.clone(), 0)
 		.is_ok());
 
 	let deaggregated_tx5 = deaggregate(tx12345.clone(), vec![tx12.clone(), tx34.clone()]).unwrap();
 	assert!(deaggregated_tx5
-		.validate(Weighting::AsTransaction, vc.clone())
+		.validate(Weighting::AsTransaction, vc.clone(), 0)
 		.is_ok());
 	assert_eq!(tx5, deaggregated_tx5);
 }
@@ -335,25 +336,25 @@ fn basic_transaction_deaggregation() {
 
 	let vc = verifier_cache();
 
-	assert!(tx1.validate(Weighting::AsTransaction, vc.clone()).is_ok());
-	assert!(tx2.validate(Weighting::AsTransaction, vc.clone()).is_ok());
+	assert!(tx1.validate(Weighting::AsTransaction, vc.clone(), 0).is_ok());
+	assert!(tx2.validate(Weighting::AsTransaction, vc.clone(), 0).is_ok());
 
 	// now build a "cut_through" tx from tx1 and tx2
 	let tx3 = aggregate(vec![tx1.clone(), tx2.clone()]).unwrap();
 
-	assert!(tx3.validate(Weighting::AsTransaction, vc.clone()).is_ok());
+	assert!(tx3.validate(Weighting::AsTransaction, vc.clone(), 0).is_ok());
 
 	let deaggregated_tx1 = deaggregate(tx3.clone(), vec![tx2.clone()]).unwrap();
 
 	assert!(deaggregated_tx1
-		.validate(Weighting::AsTransaction, vc.clone())
+		.validate(Weighting::AsTransaction, vc.clone(), 0)
 		.is_ok());
 	assert_eq!(tx1, deaggregated_tx1);
 
 	let deaggregated_tx2 = deaggregate(tx3.clone(), vec![tx1.clone()]).unwrap();
 
 	assert!(deaggregated_tx2
-		.validate(Weighting::AsTransaction, vc.clone())
+		.validate(Weighting::AsTransaction, vc.clone(), 0)
 		.is_ok());
 	assert_eq!(tx2, deaggregated_tx2);
 }
@@ -387,7 +388,7 @@ fn hash_output() {
 fn blind_tx() {
 	let btx = tx2i1o();
 	assert!(btx
-		.validate(Weighting::AsTransaction, verifier_cache())
+		.validate(Weighting::AsTransaction, verifier_cache(), 0)
 		.is_ok());
 }
 
@@ -444,7 +445,7 @@ fn tx_build_exchange() {
 	.unwrap();
 
 	tx_final
-		.validate(Weighting::AsTransaction, verifier_cache())
+		.validate(Weighting::AsTransaction, verifier_cache(), 0)
 		.unwrap();
 }
 
@@ -458,7 +459,8 @@ fn reward_empty_block() {
 
 	let b = new_block(vec![], &keychain, &builder, &previous_header, &key_id);
 
-	b.cut_through().unwrap().validate(verifier_cache()).unwrap();
+	let complete_inputs = HashMap::new();
+	b.cut_through().unwrap().validate(verifier_cache(), &complete_inputs).unwrap();
 }
 
 #[test]
@@ -470,7 +472,7 @@ fn reward_with_tx_block() {
 	let vc = verifier_cache();
 
 	let mut tx1 = tx2i1o();
-	tx1.validate(Weighting::AsTransaction, vc.clone()).unwrap();
+	tx1.validate(Weighting::AsTransaction, vc.clone(), 0).unwrap();
 
 	let previous_header = BlockHeader::default();
 
@@ -481,7 +483,8 @@ fn reward_with_tx_block() {
 		&previous_header,
 		&key_id,
 	);
-	block.cut_through().unwrap().validate(vc.clone()).unwrap();
+	let complete_inputs = HashMap::new();
+	block.cut_through().unwrap().validate(vc.clone(), &complete_inputs).unwrap();
 }
 
 #[test]
@@ -504,7 +507,8 @@ fn simple_block() {
 		&key_id,
 	);
 
-	b.validate(vc.clone()).unwrap();
+	let complete_inputs = HashMap::new();
+	b.validate(vc.clone(), &complete_inputs).unwrap();
 }
 
 #[test]
@@ -540,7 +544,8 @@ fn test_block_with_timelocked_tx() {
 		&previous_header,
 		&key_id3.clone(),
 	);
-	b.validate(vc.clone()).unwrap();
+	let complete_inputs = HashMap::new();
+	b.validate(vc.clone(), &complete_inputs).unwrap();
 
 	// now try adding a timelocked tx where lock height is greater than current
 	// block height
@@ -565,7 +570,7 @@ fn test_block_with_timelocked_tx() {
 		&key_id3.clone(),
 	);
 
-	match b.validate(vc.clone()) {
+	match b.validate(vc.clone(), &complete_inputs) {
 		Err(KernelLockHeight(height)) => {
 			assert_eq!(height, 2);
 		}
@@ -576,13 +581,13 @@ fn test_block_with_timelocked_tx() {
 #[test]
 pub fn test_verify_1i1o_sig() {
 	let tx = tx1i1o();
-	tx.validate(Weighting::AsTransaction, verifier_cache())
+	tx.validate(Weighting::AsTransaction, verifier_cache(), 0)
 		.unwrap();
 }
 
 #[test]
 pub fn test_verify_2i1o_sig() {
 	let tx = tx2i1o();
-	tx.validate(Weighting::AsTransaction, verifier_cache())
+	tx.validate(Weighting::AsTransaction, verifier_cache(), 0)
 		.unwrap();
 }

--- a/core/tests/core.rs
+++ b/core/tests/core.rs
@@ -34,8 +34,8 @@ use gotts_core as core;
 use gotts_keychain as keychain;
 use gotts_util as util;
 use serde_json;
-use std::sync::Arc;
 use std::collections::HashMap;
+use std::sync::Arc;
 
 #[test]
 fn simple_tx_ser() {
@@ -158,7 +158,9 @@ fn transaction_cut_through() {
 	// now build a "cut_through" tx from tx1 and tx2
 	let tx3 = aggregate(vec![tx1, tx2]).unwrap();
 
-	assert!(tx3.validate(Weighting::AsTransaction, vc.clone(), 0).is_ok());
+	assert!(tx3
+		.validate(Weighting::AsTransaction, vc.clone(), 0)
+		.is_ok());
 }
 
 // Attempt to deaggregate a multi-kernel transaction in a different way
@@ -171,10 +173,18 @@ fn multi_kernel_transaction_deaggregation() {
 
 	let vc = verifier_cache();
 
-	assert!(tx1.validate(Weighting::AsTransaction, vc.clone(), 0).is_ok());
-	assert!(tx2.validate(Weighting::AsTransaction, vc.clone(), 0).is_ok());
-	assert!(tx3.validate(Weighting::AsTransaction, vc.clone(), 0).is_ok());
-	assert!(tx4.validate(Weighting::AsTransaction, vc.clone(), 0).is_ok());
+	assert!(tx1
+		.validate(Weighting::AsTransaction, vc.clone(), 0)
+		.is_ok());
+	assert!(tx2
+		.validate(Weighting::AsTransaction, vc.clone(), 0)
+		.is_ok());
+	assert!(tx3
+		.validate(Weighting::AsTransaction, vc.clone(), 0)
+		.is_ok());
+	assert!(tx4
+		.validate(Weighting::AsTransaction, vc.clone(), 0)
+		.is_ok());
 
 	let tx1234 = aggregate(vec![tx1.clone(), tx2.clone(), tx3.clone(), tx4.clone()]).unwrap();
 	let tx12 = aggregate(vec![tx1.clone(), tx2.clone()]).unwrap();
@@ -183,8 +193,12 @@ fn multi_kernel_transaction_deaggregation() {
 	assert!(tx1234
 		.validate(Weighting::AsTransaction, vc.clone(), 0)
 		.is_ok());
-	assert!(tx12.validate(Weighting::AsTransaction, vc.clone(), 0).is_ok());
-	assert!(tx34.validate(Weighting::AsTransaction, vc.clone(), 0).is_ok());
+	assert!(tx12
+		.validate(Weighting::AsTransaction, vc.clone(), 0)
+		.is_ok());
+	assert!(tx34
+		.validate(Weighting::AsTransaction, vc.clone(), 0)
+		.is_ok());
 
 	let deaggregated_tx34 = deaggregate(tx1234.clone(), vec![tx12.clone()]).unwrap();
 	assert!(deaggregated_tx34
@@ -208,15 +222,25 @@ fn multi_kernel_transaction_deaggregation_2() {
 
 	let vc = verifier_cache();
 
-	assert!(tx1.validate(Weighting::AsTransaction, vc.clone(), 0).is_ok());
-	assert!(tx2.validate(Weighting::AsTransaction, vc.clone(), 0).is_ok());
-	assert!(tx3.validate(Weighting::AsTransaction, vc.clone(), 0).is_ok());
+	assert!(tx1
+		.validate(Weighting::AsTransaction, vc.clone(), 0)
+		.is_ok());
+	assert!(tx2
+		.validate(Weighting::AsTransaction, vc.clone(), 0)
+		.is_ok());
+	assert!(tx3
+		.validate(Weighting::AsTransaction, vc.clone(), 0)
+		.is_ok());
 
 	let tx123 = aggregate(vec![tx1.clone(), tx2.clone(), tx3.clone()]).unwrap();
 	let tx12 = aggregate(vec![tx1.clone(), tx2.clone()]).unwrap();
 
-	assert!(tx123.validate(Weighting::AsTransaction, vc.clone(), 0).is_ok());
-	assert!(tx12.validate(Weighting::AsTransaction, vc.clone(), 0).is_ok());
+	assert!(tx123
+		.validate(Weighting::AsTransaction, vc.clone(), 0)
+		.is_ok());
+	assert!(tx12
+		.validate(Weighting::AsTransaction, vc.clone(), 0)
+		.is_ok());
 
 	let deaggregated_tx3 = deaggregate(tx123.clone(), vec![tx12.clone()]).unwrap();
 	assert!(deaggregated_tx3
@@ -233,16 +257,26 @@ fn multi_kernel_transaction_deaggregation_3() {
 
 	let vc = verifier_cache();
 
-	assert!(tx1.validate(Weighting::AsTransaction, vc.clone(), 0).is_ok());
-	assert!(tx2.validate(Weighting::AsTransaction, vc.clone(), 0).is_ok());
-	assert!(tx3.validate(Weighting::AsTransaction, vc.clone(), 0).is_ok());
+	assert!(tx1
+		.validate(Weighting::AsTransaction, vc.clone(), 0)
+		.is_ok());
+	assert!(tx2
+		.validate(Weighting::AsTransaction, vc.clone(), 0)
+		.is_ok());
+	assert!(tx3
+		.validate(Weighting::AsTransaction, vc.clone(), 0)
+		.is_ok());
 
 	let tx123 = aggregate(vec![tx1.clone(), tx2.clone(), tx3.clone()]).unwrap();
 	let tx13 = aggregate(vec![tx1.clone(), tx3.clone()]).unwrap();
 	let tx2 = aggregate(vec![tx2.clone()]).unwrap();
 
-	assert!(tx123.validate(Weighting::AsTransaction, vc.clone(), 0).is_ok());
-	assert!(tx2.validate(Weighting::AsTransaction, vc.clone(), 0).is_ok());
+	assert!(tx123
+		.validate(Weighting::AsTransaction, vc.clone(), 0)
+		.is_ok());
+	assert!(tx2
+		.validate(Weighting::AsTransaction, vc.clone(), 0)
+		.is_ok());
 
 	let deaggregated_tx13 = deaggregate(tx123.clone(), vec![tx2.clone()]).unwrap();
 	assert!(deaggregated_tx13
@@ -261,11 +295,21 @@ fn multi_kernel_transaction_deaggregation_4() {
 
 	let vc = verifier_cache();
 
-	assert!(tx1.validate(Weighting::AsTransaction, vc.clone(), 0).is_ok());
-	assert!(tx2.validate(Weighting::AsTransaction, vc.clone(), 0).is_ok());
-	assert!(tx3.validate(Weighting::AsTransaction, vc.clone(), 0).is_ok());
-	assert!(tx4.validate(Weighting::AsTransaction, vc.clone(), 0).is_ok());
-	assert!(tx5.validate(Weighting::AsTransaction, vc.clone(), 0).is_ok());
+	assert!(tx1
+		.validate(Weighting::AsTransaction, vc.clone(), 0)
+		.is_ok());
+	assert!(tx2
+		.validate(Weighting::AsTransaction, vc.clone(), 0)
+		.is_ok());
+	assert!(tx3
+		.validate(Weighting::AsTransaction, vc.clone(), 0)
+		.is_ok());
+	assert!(tx4
+		.validate(Weighting::AsTransaction, vc.clone(), 0)
+		.is_ok());
+	assert!(tx5
+		.validate(Weighting::AsTransaction, vc.clone(), 0)
+		.is_ok());
 
 	let tx12345 = aggregate(vec![
 		tx1.clone(),
@@ -300,11 +344,21 @@ fn multi_kernel_transaction_deaggregation_5() {
 
 	let vc = verifier_cache();
 
-	assert!(tx1.validate(Weighting::AsTransaction, vc.clone(), 0).is_ok());
-	assert!(tx2.validate(Weighting::AsTransaction, vc.clone(), 0).is_ok());
-	assert!(tx3.validate(Weighting::AsTransaction, vc.clone(), 0).is_ok());
-	assert!(tx4.validate(Weighting::AsTransaction, vc.clone(), 0).is_ok());
-	assert!(tx5.validate(Weighting::AsTransaction, vc.clone(), 0).is_ok());
+	assert!(tx1
+		.validate(Weighting::AsTransaction, vc.clone(), 0)
+		.is_ok());
+	assert!(tx2
+		.validate(Weighting::AsTransaction, vc.clone(), 0)
+		.is_ok());
+	assert!(tx3
+		.validate(Weighting::AsTransaction, vc.clone(), 0)
+		.is_ok());
+	assert!(tx4
+		.validate(Weighting::AsTransaction, vc.clone(), 0)
+		.is_ok());
+	assert!(tx5
+		.validate(Weighting::AsTransaction, vc.clone(), 0)
+		.is_ok());
 
 	let tx12345 = aggregate(vec![
 		tx1.clone(),
@@ -336,13 +390,19 @@ fn basic_transaction_deaggregation() {
 
 	let vc = verifier_cache();
 
-	assert!(tx1.validate(Weighting::AsTransaction, vc.clone(), 0).is_ok());
-	assert!(tx2.validate(Weighting::AsTransaction, vc.clone(), 0).is_ok());
+	assert!(tx1
+		.validate(Weighting::AsTransaction, vc.clone(), 0)
+		.is_ok());
+	assert!(tx2
+		.validate(Weighting::AsTransaction, vc.clone(), 0)
+		.is_ok());
 
 	// now build a "cut_through" tx from tx1 and tx2
 	let tx3 = aggregate(vec![tx1.clone(), tx2.clone()]).unwrap();
 
-	assert!(tx3.validate(Weighting::AsTransaction, vc.clone(), 0).is_ok());
+	assert!(tx3
+		.validate(Weighting::AsTransaction, vc.clone(), 0)
+		.is_ok());
 
 	let deaggregated_tx1 = deaggregate(tx3.clone(), vec![tx2.clone()]).unwrap();
 
@@ -460,7 +520,10 @@ fn reward_empty_block() {
 	let b = new_block(vec![], &keychain, &builder, &previous_header, &key_id);
 
 	let complete_inputs = HashMap::new();
-	b.cut_through().unwrap().validate(verifier_cache(), &complete_inputs).unwrap();
+	b.cut_through()
+		.unwrap()
+		.validate(verifier_cache(), &complete_inputs)
+		.unwrap();
 }
 
 #[test]
@@ -472,7 +535,8 @@ fn reward_with_tx_block() {
 	let vc = verifier_cache();
 
 	let mut tx1 = tx2i1o();
-	tx1.validate(Weighting::AsTransaction, vc.clone(), 0).unwrap();
+	tx1.validate(Weighting::AsTransaction, vc.clone(), 0)
+		.unwrap();
 
 	let previous_header = BlockHeader::default();
 
@@ -484,7 +548,11 @@ fn reward_with_tx_block() {
 		&key_id,
 	);
 	let complete_inputs = HashMap::new();
-	block.cut_through().unwrap().validate(vc.clone(), &complete_inputs).unwrap();
+	block
+		.cut_through()
+		.unwrap()
+		.validate(vc.clone(), &complete_inputs)
+		.unwrap();
 }
 
 #[test]

--- a/keychain/src/types.rs
+++ b/keychain/src/types.rs
@@ -478,8 +478,15 @@ pub trait Keychain: Sync + Send + Clone {
 	fn commit_raw(&self, w: i64, key: &SecretKey) -> Result<Commitment, Error>;
 	fn blind_sum(&self, blind_sum: &BlindSum) -> Result<BlindingFactor, Error>;
 	fn rewind_nonce(&self, commit: &Commitment) -> Result<SecretKey, Error>;
+
+	/// ECDSA Signature.
+	/// Note: only used for test. For production, we use Schnorr Signature instead.
 	fn sign(&self, msg: &Message, id: &Identifier) -> Result<Signature, Error>;
+
+	/// ECDSA Signature.
+	/// Note: only used for test. For production, we use Schnorr Signature instead.
 	fn sign_with_blinding(&self, _: &Message, _: &BlindingFactor) -> Result<Signature, Error>;
+
 	fn secp(&self) -> &Secp256k1;
 }
 

--- a/pool/src/pool.rs
+++ b/pool/src/pool.rs
@@ -166,7 +166,11 @@ impl Pool {
 		let tx = transaction::aggregate(txs)?;
 
 		// Validate the single aggregate transaction "as pool", not subject to tx weight limits.
-		tx.validate(Weighting::NoLimit, self.verifier_cache.clone(), self.blockchain.chain_head()?.height)?;
+		tx.validate(
+			Weighting::NoLimit,
+			self.verifier_cache.clone(),
+			self.blockchain.chain_head()?.height,
+		)?;
 
 		Ok(Some(tx))
 	}

--- a/pool/src/pool.rs
+++ b/pool/src/pool.rs
@@ -21,7 +21,7 @@ use self::core::core::id::{ShortId, ShortIdentifiable};
 use self::core::core::transaction;
 use self::core::core::verifier_cache::VerifierCache;
 use self::core::core::{
-	Block, BlockHeader, BlockSums, Committed, Transaction, TxKernel, Weighting,
+	Block, BlockHeader, BlockSums, Committed, Input, Output, Transaction, TxKernel, Weighting,
 };
 use self::util::RwLock;
 use crate::types::{BlockChain, PoolEntry, PoolError};
@@ -73,6 +73,16 @@ impl Pool {
 				if k.hash() == hash {
 					return Some(x.tx.clone());
 				}
+			}
+		}
+		None
+	}
+
+	/// Query the tx pool for an individual input.
+	pub fn retrieve_output_by_input(&self, input: &Input) -> Option<Output> {
+		for x in &self.entries {
+			if let Some(o) = x.tx.find_output_by_commit(&input.commit) {
+				return Some(o.clone());
 			}
 		}
 		None
@@ -156,7 +166,7 @@ impl Pool {
 		let tx = transaction::aggregate(txs)?;
 
 		// Validate the single aggregate transaction "as pool", not subject to tx weight limits.
-		tx.validate(Weighting::NoLimit, self.verifier_cache.clone())?;
+		tx.validate(Weighting::NoLimit, self.verifier_cache.clone(), self.blockchain.chain_head()?.height)?;
 
 		Ok(Some(tx))
 	}
@@ -223,7 +233,7 @@ impl Pool {
 	) -> Result<BlockSums, PoolError> {
 		// Validate the tx, conditionally checking against weight limits,
 		// based on weight verification type.
-		tx.validate(weighting, self.verifier_cache.clone())?;
+		tx.validate(weighting, self.verifier_cache.clone(), header.height)?;
 
 		// Validate the tx against current chain state.
 		// Check all inputs are in the current UTXO set.
@@ -368,6 +378,7 @@ impl Pool {
 						entry.tx.clone(),
 						weighting,
 						self.verifier_cache.clone(),
+						self.blockchain.chain_head().unwrap().height,
 					) {
 						if new_bucket.fee_to_weight >= bucket.fee_to_weight {
 							// Only aggregate if it would not reduce the fee_to_weight ratio.
@@ -478,14 +489,15 @@ impl Bucket {
 		new_tx: Transaction,
 		weighting: Weighting,
 		verifier_cache: Arc<RwLock<dyn VerifierCache>>,
+		height: u64,
 	) -> Result<Bucket, PoolError> {
 		let mut raw_txs = self.raw_txs.clone();
 		raw_txs.push(new_tx);
 		let agg_tx = transaction::aggregate(raw_txs.clone())?;
-		agg_tx.validate(weighting, verifier_cache)?;
+		agg_tx.validate(weighting, verifier_cache, height)?;
 		Ok(Bucket {
 			fee_to_weight: agg_tx.fee_to_weight(),
-			raw_txs: raw_txs,
+			raw_txs,
 			age_idx: self.age_idx,
 		})
 	}

--- a/pool/src/transaction_pool.rs
+++ b/pool/src/transaction_pool.rs
@@ -106,7 +106,11 @@ impl TransactionPool {
 				let tx = transaction::deaggregate(entry.tx, txs)?;
 
 				// Validate this deaggregated tx "as tx", subject to regular tx weight limits.
-				tx.validate(Weighting::AsTransaction, self.verifier_cache.clone(), header.height)?;
+				tx.validate(
+					Weighting::AsTransaction,
+					self.verifier_cache.clone(),
+					header.height,
+				)?;
 
 				entry.tx = tx;
 				entry.src = TxSource::Deaggregate;
@@ -161,9 +165,23 @@ impl TransactionPool {
 			for input in inputs {
 				if !complete_inputs.contains_key(&input.commit) {
 					if let Some(o) = self.txpool.retrieve_output_by_input(&input) {
-						complete_inputs.insert(input.commit.clone(), OutputEx { output: o, height: 0, mmr_index: 0 });
+						complete_inputs.insert(
+							input.commit.clone(),
+							OutputEx {
+								output: o,
+								height: 0,
+								mmr_index: 0,
+							},
+						);
 					} else if let Some(o) = self.stempool.retrieve_output_by_input(&input) {
-						complete_inputs.insert(input.commit.clone(), OutputEx { output: o, height: 0, mmr_index: 0 });
+						complete_inputs.insert(
+							input.commit.clone(),
+							OutputEx {
+								output: o,
+								height: 0,
+								mmr_index: 0,
+							},
+						);
 					} else {
 						return Err(PoolError::InvalidTx(transaction::Error::InputNotExist));
 					}
@@ -174,8 +192,12 @@ impl TransactionPool {
 
 		// Make sure the transaction is valid before anything else.
 		// Validate tx accounting for max tx weight.
-		tx.validate(Weighting::AsTransaction, self.verifier_cache.clone(), header.height)
-			.map_err(PoolError::InvalidTx)?;
+		tx.validate(
+			Weighting::AsTransaction,
+			self.verifier_cache.clone(),
+			header.height,
+		)
+		.map_err(PoolError::InvalidTx)?;
 
 		// Check the tx lock_time is valid based on current chain state.
 		self.blockchain.verify_tx_lock_height(&tx)?;

--- a/pool/src/types.rs
+++ b/pool/src/types.rs
@@ -21,12 +21,15 @@ use chrono::prelude::{DateTime, Utc};
 use self::core::core::block;
 use self::core::core::committed;
 use self::core::core::hash::Hash;
-use self::core::core::transaction::{self, Transaction};
+use self::core::core::transaction::{self, Input, OutputEx, Transaction};
 use self::core::core::{BlockHeader, BlockSums};
 use self::core::{consensus, global};
+use self::util::secp::pedersen::Commitment;
 use failure::Fail;
 use gotts_core as core;
+use gotts_util as util;
 use gotts_keychain as keychain;
+use std::collections::HashMap;
 
 /// Dandelion "epoch" length.
 const DANDELION_EPOCH_SECS: u16 = 600;
@@ -253,6 +256,9 @@ impl From<committed::Error> for PoolError {
 
 /// Interface that the pool requires from a blockchain implementation.
 pub trait BlockChain: Sync + Send {
+	/// Find the complete input/s info, use chain database data according to inputs
+	fn get_complete_inputs(&self, inputs: &Vec<Input>) -> Result<HashMap<Commitment, OutputEx>, PoolError>;
+
 	/// Verify any coinbase outputs being spent
 	/// have matured sufficiently.
 	fn verify_coinbase_maturity(&self, tx: &transaction::Transaction) -> Result<(), PoolError>;

--- a/pool/src/types.rs
+++ b/pool/src/types.rs
@@ -27,8 +27,8 @@ use self::core::{consensus, global};
 use self::util::secp::pedersen::Commitment;
 use failure::Fail;
 use gotts_core as core;
-use gotts_util as util;
 use gotts_keychain as keychain;
+use gotts_util as util;
 use std::collections::HashMap;
 
 /// Dandelion "epoch" length.
@@ -257,7 +257,10 @@ impl From<committed::Error> for PoolError {
 /// Interface that the pool requires from a blockchain implementation.
 pub trait BlockChain: Sync + Send {
 	/// Find the complete input/s info, use chain database data according to inputs
-	fn get_complete_inputs(&self, inputs: &Vec<Input>) -> Result<HashMap<Commitment, OutputEx>, PoolError>;
+	fn get_complete_inputs(
+		&self,
+		inputs: &Vec<Input>,
+	) -> Result<HashMap<Commitment, OutputEx>, PoolError>;
 
 	/// Verify any coinbase outputs being spent
 	/// have matured sufficiently.

--- a/pool/tests/block_building.rs
+++ b/pool/tests/block_building.rs
@@ -147,7 +147,7 @@ fn test_transaction_pool_block_building() {
 			// Add this bad tx to the pool.
 			assert_eq!(
 				write_pool.add_to_pool(test_source(), bad_tx_1.clone(), false, &header),
-				Err(PoolError::Other(format!("transaction sum mismatch"))),
+				Err(PoolError::InvalidTx(core::core::transaction::Error::TransactionSumMismatch)),
 			);
 			assert_eq!(write_pool.total_size(), 0);
 
@@ -158,7 +158,7 @@ fn test_transaction_pool_block_building() {
 				.unwrap();
 			assert_eq!(
 				write_pool.add_to_pool(test_source(), bad_tx_2.clone(), false, &header),
-				Err(PoolError::Other(format!("transaction sum mismatch"))),
+				Err(PoolError::InvalidTx(core::core::transaction::Error::TransactionSumMismatch)),
 			);
 			assert_eq!(write_pool.total_size(), 1);
 		}

--- a/pool/tests/block_building.rs
+++ b/pool/tests/block_building.rs
@@ -147,7 +147,9 @@ fn test_transaction_pool_block_building() {
 			// Add this bad tx to the pool.
 			assert_eq!(
 				write_pool.add_to_pool(test_source(), bad_tx_1.clone(), false, &header),
-				Err(PoolError::InvalidTx(core::core::transaction::Error::TransactionSumMismatch)),
+				Err(PoolError::InvalidTx(
+					core::core::transaction::Error::TransactionSumMismatch
+				)),
 			);
 			assert_eq!(write_pool.total_size(), 0);
 
@@ -158,7 +160,9 @@ fn test_transaction_pool_block_building() {
 				.unwrap();
 			assert_eq!(
 				write_pool.add_to_pool(test_source(), bad_tx_2.clone(), false, &header),
-				Err(PoolError::InvalidTx(core::core::transaction::Error::TransactionSumMismatch)),
+				Err(PoolError::InvalidTx(
+					core::core::transaction::Error::TransactionSumMismatch
+				)),
 			);
 			assert_eq!(write_pool.total_size(), 1);
 		}

--- a/pool/tests/coinbase_maturity.rs
+++ b/pool/tests/coinbase_maturity.rs
@@ -17,18 +17,18 @@ pub mod common;
 
 use self::core::core::hash::Hash;
 use self::core::core::verifier_cache::LruVerifierCache;
-use self::core::core::{BlockHeader, BlockSums, Transaction, Input, OutputEx};
+use self::core::core::{BlockHeader, BlockSums, Input, OutputEx, Transaction};
 use self::keychain::{ExtKeychain, Keychain};
 use self::pool::types::{BlockChain, PoolError};
-use self::util::RwLock;
 use self::util::secp::pedersen::Commitment;
+use self::util::RwLock;
 use crate::common::*;
 use gotts_core as core;
 use gotts_keychain as keychain;
 use gotts_pool as pool;
 use gotts_util as util;
-use std::sync::Arc;
 use std::collections::HashMap;
+use std::sync::Arc;
 
 #[derive(Clone)]
 pub struct CoinbaseMaturityErrorChainAdapter {}
@@ -56,7 +56,10 @@ impl BlockChain for CoinbaseMaturityErrorChainAdapter {
 		unimplemented!();
 	}
 
-	fn get_complete_inputs(&self, _inputs: &Vec<Input>) -> Result<HashMap<Commitment, OutputEx>, pool::PoolError> {
+	fn get_complete_inputs(
+		&self,
+		_inputs: &Vec<Input>,
+	) -> Result<HashMap<Commitment, OutputEx>, pool::PoolError> {
 		Ok(HashMap::new())
 	}
 

--- a/pool/tests/coinbase_maturity.rs
+++ b/pool/tests/coinbase_maturity.rs
@@ -17,16 +17,18 @@ pub mod common;
 
 use self::core::core::hash::Hash;
 use self::core::core::verifier_cache::LruVerifierCache;
-use self::core::core::{BlockHeader, BlockSums, Transaction};
+use self::core::core::{BlockHeader, BlockSums, Transaction, Input, OutputEx};
 use self::keychain::{ExtKeychain, Keychain};
 use self::pool::types::{BlockChain, PoolError};
 use self::util::RwLock;
+use self::util::secp::pedersen::Commitment;
 use crate::common::*;
 use gotts_core as core;
 use gotts_keychain as keychain;
 use gotts_pool as pool;
 use gotts_util as util;
 use std::sync::Arc;
+use std::collections::HashMap;
 
 #[derive(Clone)]
 pub struct CoinbaseMaturityErrorChainAdapter {}
@@ -52,6 +54,10 @@ impl BlockChain for CoinbaseMaturityErrorChainAdapter {
 
 	fn validate_tx(&self, _tx: &Transaction) -> Result<(), PoolError> {
 		unimplemented!();
+	}
+
+	fn get_complete_inputs(&self, _inputs: &Vec<Input>) -> Result<HashMap<Commitment, OutputEx>, pool::PoolError> {
+		Ok(HashMap::new())
 	}
 
 	// Returns an ImmatureCoinbase for every tx we pass in.
@@ -81,6 +87,7 @@ fn test_coinbase_maturity() {
 		let tx = test_transaction(&keychain, vec![50], vec![49]);
 		match write_pool.add_to_pool(test_source(), tx.clone(), true, &BlockHeader::default()) {
 			Err(PoolError::ImmatureCoinbase) => {}
+			Err(PoolError::InvalidTx(core::core::transaction::Error::InputNotExist)) => {}
 			_ => panic!("Expected an immature coinbase error here."),
 		}
 	}

--- a/pool/tests/common.rs
+++ b/pool/tests/common.rs
@@ -92,12 +92,13 @@ impl ChainAdapter {
 				utxo.remove(&x.commitment());
 			}
 			for x in block.outputs() {
-				utxo.insert(x.commitment(),
-							OutputEx {
-								output: x.clone(),
-								height: header.height,
-								mmr_index: 0, // not used here
-							}
+				utxo.insert(
+					x.commitment(),
+					OutputEx {
+						output: x.clone(),
+						height: header.height,
+						mmr_index: 0, // not used here
+					},
 				);
 			}
 		}
@@ -147,7 +148,10 @@ impl BlockChain for ChainAdapter {
 		Ok(())
 	}
 
-	fn get_complete_inputs(&self, inputs: &Vec<Input>) -> Result<HashMap<Commitment, OutputEx>, pool::PoolError> {
+	fn get_complete_inputs(
+		&self,
+		inputs: &Vec<Input>,
+	) -> Result<HashMap<Commitment, OutputEx>, pool::PoolError> {
 		let utxo = self.utxo.read();
 		let mut complete_inputs: HashMap<Commitment, OutputEx> = HashMap::new();
 		for input in inputs {
@@ -159,7 +163,7 @@ impl BlockChain for ChainAdapter {
 						output: output_ex.output.clone(),
 						height: output_ex.height,
 						mmr_index: output_ex.mmr_index,
-					}
+					},
 				);
 			}
 		}

--- a/pool/tests/transaction_pool.rs
+++ b/pool/tests/transaction_pool.rs
@@ -28,6 +28,7 @@ use gotts_keychain as keychain;
 use gotts_pool as pool;
 use gotts_util as util;
 use std::sync::Arc;
+use gotts_pool::BlockChain;
 
 /// Test we can add some txs to the pool (both stempool and txpool).
 #[test]
@@ -231,7 +232,7 @@ fn test_the_transaction_pool() {
 		let agg_tx = transaction::aggregate(vec![tx1.clone(), tx2.clone(), tx4]).unwrap();
 
 		agg_tx
-			.validate(Weighting::AsTransaction, verifier_cache.clone())
+			.validate(Weighting::AsTransaction, verifier_cache.clone(), chain.chain_head().unwrap().height)
 			.unwrap();
 
 		write_pool
@@ -441,7 +442,7 @@ fn test_the_transaction_pool() {
 			let agg_tx = transaction::aggregate(vec![tx1.clone(), tx2.clone(), tx4]).unwrap();
 
 			agg_tx
-				.validate(Weighting::AsTransaction, verifier_cache.clone())
+				.validate(Weighting::AsTransaction, verifier_cache.clone(), chain.chain_head().unwrap().height)
 				.unwrap();
 
 			write_pool

--- a/pool/tests/transaction_pool.rs
+++ b/pool/tests/transaction_pool.rs
@@ -26,9 +26,9 @@ use crate::common::*;
 use gotts_core as core;
 use gotts_keychain as keychain;
 use gotts_pool as pool;
+use gotts_pool::BlockChain;
 use gotts_util as util;
 use std::sync::Arc;
-use gotts_pool::BlockChain;
 
 /// Test we can add some txs to the pool (both stempool and txpool).
 #[test]
@@ -232,7 +232,11 @@ fn test_the_transaction_pool() {
 		let agg_tx = transaction::aggregate(vec![tx1.clone(), tx2.clone(), tx4]).unwrap();
 
 		agg_tx
-			.validate(Weighting::AsTransaction, verifier_cache.clone(), chain.chain_head().unwrap().height)
+			.validate(
+				Weighting::AsTransaction,
+				verifier_cache.clone(),
+				chain.chain_head().unwrap().height,
+			)
 			.unwrap();
 
 		write_pool
@@ -442,7 +446,11 @@ fn test_the_transaction_pool() {
 			let agg_tx = transaction::aggregate(vec![tx1.clone(), tx2.clone(), tx4]).unwrap();
 
 			agg_tx
-				.validate(Weighting::AsTransaction, verifier_cache.clone(), chain.chain_head().unwrap().height)
+				.validate(
+					Weighting::AsTransaction,
+					verifier_cache.clone(),
+					chain.chain_head().unwrap().height,
+				)
 				.unwrap();
 
 			write_pool

--- a/servers/src/common/adapters.rs
+++ b/servers/src/common/adapters.rs
@@ -36,8 +36,8 @@ use crate::core::{core, global};
 use crate::p2p;
 use crate::p2p::types::PeerInfo;
 use crate::pool;
-use crate::util::OneTime;
 use crate::util::secp::pedersen::Commitment;
+use crate::util::OneTime;
 use chrono::prelude::*;
 use chrono::Duration;
 use rand::prelude::*;
@@ -216,7 +216,10 @@ impl p2p::ChainAdapter for NetToChainAdapter {
 
 			if let Ok(_prev) = self.chain().get_previous_header(&cb.header) {
 				let complete_inputs = self.chain().get_complete_inputs(&block.inputs())?;
-				if block.validate(self.verifier_cache.clone(), &complete_inputs).is_ok() {
+				if block
+					.validate(self.verifier_cache.clone(), &complete_inputs)
+					.is_ok()
+				{
 					debug!("successfully hydrated block from tx pool!");
 					self.process_block(block, peer_info, false)
 				} else {
@@ -938,7 +941,10 @@ impl pool::BlockChain for PoolToChainAdapter {
 			.map_err(|_| pool::PoolError::Other(format!("failed to validate tx")))
 	}
 
-	fn get_complete_inputs(&self, inputs: &Vec<Input>) -> Result<HashMap<Commitment, OutputEx>, pool::PoolError> {
+	fn get_complete_inputs(
+		&self,
+		inputs: &Vec<Input>,
+	) -> Result<HashMap<Commitment, OutputEx>, pool::PoolError> {
 		self.chain()
 			.get_complete_inputs(inputs)
 			.map_err(|e| pool::PoolError::Other(format!("failed to get_complete_inputs for {}", e)))

--- a/servers/src/common/adapters.rs
+++ b/servers/src/common/adapters.rs
@@ -30,16 +30,18 @@ use crate::common::types::{ChainValidationMode, DandelionEpoch, ServerConfig};
 use crate::core::core::hash::{Hash, Hashed};
 use crate::core::core::transaction::Transaction;
 use crate::core::core::verifier_cache::VerifierCache;
-use crate::core::core::{BlockHeader, BlockSums, CompactBlock};
+use crate::core::core::{BlockHeader, BlockSums, CompactBlock, Input, OutputEx};
 use crate::core::pow::Difficulty;
 use crate::core::{core, global};
 use crate::p2p;
 use crate::p2p::types::PeerInfo;
 use crate::pool;
 use crate::util::OneTime;
+use crate::util::secp::pedersen::Commitment;
 use chrono::prelude::*;
 use chrono::Duration;
 use rand::prelude::*;
+use std::collections::HashMap;
 
 /// Implementation of the NetAdapter for the . Gets notified when new
 /// blocks and transactions are received and forwards to the chain and pool
@@ -213,7 +215,8 @@ impl p2p::ChainAdapter for NetToChainAdapter {
 			};
 
 			if let Ok(_prev) = self.chain().get_previous_header(&cb.header) {
-				if block.validate(self.verifier_cache.clone()).is_ok() {
+				let complete_inputs = self.chain().get_complete_inputs(&block.inputs())?;
+				if block.validate(self.verifier_cache.clone(), &complete_inputs).is_ok() {
 					debug!("successfully hydrated block from tx pool!");
 					self.process_block(block, peer_info, false)
 				} else {
@@ -933,6 +936,12 @@ impl pool::BlockChain for PoolToChainAdapter {
 		self.chain()
 			.validate_tx(tx)
 			.map_err(|_| pool::PoolError::Other(format!("failed to validate tx")))
+	}
+
+	fn get_complete_inputs(&self, inputs: &Vec<Input>) -> Result<HashMap<Commitment, OutputEx>, pool::PoolError> {
+		self.chain()
+			.get_complete_inputs(inputs)
+			.map_err(|e| pool::PoolError::Other(format!("failed to get_complete_inputs for {}", e)))
 	}
 
 	fn verify_coinbase_maturity(&self, tx: &Transaction) -> Result<(), pool::PoolError> {

--- a/servers/src/gotts/dandelion_monitor.rs
+++ b/servers/src/gotts/dandelion_monitor.rs
@@ -146,6 +146,7 @@ fn process_fluff_phase(
 	agg_tx.validate(
 		transaction::Weighting::AsTransaction,
 		verifier_cache.clone(),
+		header.height,
 	)?;
 
 	tx_pool.add_to_pool(TxSource::Fluff, agg_tx, false, &header)?;

--- a/servers/src/mining/mine_block.rs
+++ b/servers/src/mining/mine_block.rs
@@ -181,7 +181,8 @@ fn build_block(
 	let mut b = core::Block::from_reward(&head, txs, output, kernel, difficulty.difficulty)?;
 
 	// making sure we're not spending time mining a useless block
-	b.validate(verifier_cache)?;
+	let complete_inputs = chain.get_complete_inputs(&b.inputs())?;
+	b.validate(verifier_cache, &complete_inputs)?;
 
 	b.header.pow.nonce = thread_rng().gen();
 	b.header.pow.secondary_scaling = difficulty.secondary_scaling;


### PR DESCRIPTION
To complete some remaining parts of [PR: Non-Interactive Transaction feature](https://github.com/gottstech/gotts/pull/10):
- [x] InputEx signature verification when spend SigLocked output
- [x] Signature Batch Verification
- [x] Cache for InputEx verify
- [x] Add some tests for InputEx signature verification

And a mistake found on the `siglocked_input` build function, it was using ECDSA signature instead of the Schnorr signature, because of the confusing ` keychain.sign` and ` keychain.verify` function name which should be default using the Schnorr instead of ECDSA. (I will take care of this in another PR to refact the `keychain` module.)

Note: Because above mistake, this PR become a `consensus breaking` PR.
