### PR TITLE
fix: current_state.current_key_id updating should not stay outside of the lock

### DIFF
--- a/core/src/core/transaction.rs
+++ b/core/src/core/transaction.rs
@@ -1204,12 +1204,16 @@ impl Transaction {
 			let mut sum: i64 = complete_inputs
 				.values()
 				.fold(0i64, |acc, x| acc.saturating_add(x.output.value as i64));
+			let total_inputs_values = sum;
 			sum = self
 				.body
 				.outputs
 				.iter()
 				.fold(sum, |acc, x| acc.saturating_sub(x.value as i64));
 			if sum != self.overage() {
+				debug!("tx {} sum validate fail. total inputs value: {}, total outputs value: {}, fee: {}",
+					  self.hash(), total_inputs_values, total_inputs_values - sum, self.overage(),
+				);
 				return Err(Error::TransactionSumMismatch)?;
 			}
 		}


### PR DESCRIPTION
In case of the mineable transactions in `tx_pool` increased, and if we're resending a updated block to miner, and if a `handle_submit` just found the share is a new block, there's a race condition here to use the obsoleted `self.current_state.current_key_id` (which was used in previous block and should be reset for next mining block).

The consequence of this bug is there's possible to update a wrong coinbase output info in miner's wallet, with wrong block rewards (different fees).

For example, I saw a happening here:
```
-----------------------------------------------------------------------------------------------------------------------------------------------------------------
 Output Commitment                                                   MMR Index  Block Height  Locked Until  Status   Coinbase?  Change?  # Confirms  Value   Tx 
=================================================================================================================================================================

-----------------------------------------------------------------------------------------------------------------------------------------------------------------
 090eb8b3fe42bd0c407f5bddd9c786523f6b7fc1589d6fe5cf1e819a9164d90f2d  None       1069          1129          Mining   true       false    0           60.015   
-----------------------------------------------------------------------------------------------------------------------------------------------------------------
```
And this coinbase output in wallet suddenly change to a wrong one:
```
-----------------------------------------------------------------------------------------------------------------------------------------------------------------
 090eb8b3fe42bd0c407f5bddd9c786523f6b7fc1589d6fe5cf1e819a9164d90f2d  None       1069          1130          Unspent  true       false    1           60.008  161 
-----------------------------------------------------------------------------------------------------------------------------------------------------------------
```