### PR TITLE
consensus: floonet use smaller threshold for state sync

### DIFF
--- a/core/src/global.rs
+++ b/core/src/global.rs
@@ -273,7 +273,8 @@ pub fn cut_through_horizon() -> u32 {
 	match *param_ref {
 		ChainTypes::AutomatedTesting => AUTOMATED_TESTING_CUT_THROUGH_HORIZON,
 		ChainTypes::UserTesting => USER_TESTING_CUT_THROUGH_HORIZON,
-		_ => CUT_THROUGH_HORIZON,
+		ChainTypes::Floonet => CUT_THROUGH_HORIZON / 24,
+		ChainTypes::Mainnet => CUT_THROUGH_HORIZON,
 	}
 }
 
@@ -283,7 +284,8 @@ pub fn state_sync_threshold() -> u32 {
 	match *param_ref {
 		ChainTypes::AutomatedTesting => TESTING_STATE_SYNC_THRESHOLD,
 		ChainTypes::UserTesting => TESTING_STATE_SYNC_THRESHOLD,
-		_ => STATE_SYNC_THRESHOLD,
+		ChainTypes::Floonet => STATE_SYNC_THRESHOLD / 24,
+		ChainTypes::Mainnet => STATE_SYNC_THRESHOLD,
 	}
 }
 
@@ -293,7 +295,8 @@ pub fn txhashset_archive_interval() -> u64 {
 	match *param_ref {
 		ChainTypes::AutomatedTesting => TESTING_TXHASHSET_ARCHIVE_INTERVAL,
 		ChainTypes::UserTesting => TESTING_TXHASHSET_ARCHIVE_INTERVAL,
-		_ => TXHASHSET_ARCHIVE_INTERVAL,
+		ChainTypes::Floonet => TXHASHSET_ARCHIVE_INTERVAL / 24,
+		ChainTypes::Mainnet => TXHASHSET_ARCHIVE_INTERVAL,
 	}
 }
 


### PR DESCRIPTION
For the convenience of Floonet test for state sync and cut-through, adjust the three consensus const:
1. `cut_through_horizon`: 
  - mainnet use 28 days (i.e. `40,320`) blocks
  - floonet use 28 hours (i.e. `1,680`)blocks.
2. `state_sync_threshold`:
  - mainnet use 7 days (i.e. `10,080`) blocks
  - floonet use 7 hours (i.e. `420`) blocks.
3. `txhashset_archive_interval`: 
  - mainnet use 0.5 day (i.e. `720`) blocks
  - floonet use 0.5 hour (i.e. `30`) blocks.

**Note**: Must remember to change back when mainnet launching! to keep the floonet exact same as the mainnet except the Genesis block.

