### PR TITLE
fix: the tx_weight calculation mistake for input length

### DIFF
--- a/core/src/core/transaction.rs
+++ b/core/src/core/transaction.rs
@@ -746,12 +746,20 @@ impl TransactionBody {
 
 	/// Calculate transaction weight
 	pub fn body_weight(&self) -> usize {
-		TransactionBody::weight(self.inputs.len(), self.outputs.len(), self.kernels.len())
+		TransactionBody::weight(
+			self.get_inputs_number(),
+			self.outputs.len(),
+			self.kernels.len(),
+		)
 	}
 
 	/// Calculate weight of transaction using block weighing
 	pub fn body_weight_as_block(&self) -> usize {
-		TransactionBody::weight_as_block(self.inputs.len(), self.outputs.len(), self.kernels.len())
+		TransactionBody::weight_as_block(
+			self.get_inputs_number(),
+			self.outputs.len(),
+			self.kernels.len(),
+		)
 	}
 
 	/// Calculate transaction weight from transaction details. This is non

--- a/keychain/src/types.rs
+++ b/keychain/src/types.rs
@@ -391,7 +391,7 @@ impl ExtKeychainPath {
 	/// Return a new chain path with given derivation and depth
 	pub fn new(depth: u8, d0: u32, d1: u32, d2: u32, d3: u32) -> ExtKeychainPath {
 		ExtKeychainPath {
-			depth: depth,
+			depth,
 			path: [
 				ChildNumber::from(d0),
 				ChildNumber::from(d1),
@@ -401,7 +401,7 @@ impl ExtKeychainPath {
 		}
 	}
 
-	/// from an Indentifier [manual deserialization]
+	/// from an Identifier [manual deserialization]
 	pub fn from_identifier(id: &Identifier) -> ExtKeychainPath {
 		let mut rdr = Cursor::new(id.0.to_vec());
 		ExtKeychainPath {


### PR DESCRIPTION
A mistake on the transaction weight calculation.

Root cause:  the `self.inputs.len()` is no more the meaning of before, since now the `inputs` are:
```Rust
pub inputs: Vec<InputEx>
```
which is `InputEx` vector other than `Input` vector.

