### PR TITLE
notify the download failure so as to quickly restart a new request

### DIFF
--- a/p2p/src/peer.rs
+++ b/p2p/src/peer.rs
@@ -595,6 +595,10 @@ impl ChainAdapter for TrackingAdapter {
 		self.adapter.txhashset_write(h, txhashset_data, peer_info)
 	}
 
+	fn txhashset_download_fail(&self, fail_reason: String) {
+		self.adapter.txhashset_download_fail(fail_reason);
+	}
+
 	fn txhashset_download_update(
 		&self,
 		start_time: DateTime<Utc>,

--- a/p2p/src/peers.rs
+++ b/p2p/src/peers.rs
@@ -705,6 +705,10 @@ impl ChainAdapter for Peers {
 		}
 	}
 
+	fn txhashset_download_fail(&self, fail_reason: String) {
+		self.adapter.txhashset_download_fail(fail_reason);
+	}
+
 	fn txhashset_download_update(
 		&self,
 		start_time: DateTime<Utc>,

--- a/p2p/src/protocol.rs
+++ b/p2p/src/protocol.rs
@@ -427,6 +427,7 @@ impl MessageHandler for Protocol {
 						"handle_payload: txhashset archive save to file fail. err={:?}",
 						e
 					);
+					self.adapter.txhashset_download_fail(format!("{:?}", e));
 					return Err(e);
 				}
 

--- a/p2p/src/serv.rs
+++ b/p2p/src/serv.rs
@@ -85,6 +85,9 @@ impl Server {
 
 			match listener.accept() {
 				Ok((stream, peer_addr)) => {
+					// Explicitly move the accepted TCP stream into blocking mode.
+					stream.set_nonblocking(false)?;
+
 					let peer_addr = PeerAddr(peer_addr);
 
 					if self.check_undesirable(&stream) {
@@ -330,6 +333,10 @@ impl ChainAdapter for DummyAdapter {
 		_peer_info: &PeerInfo,
 	) -> Result<bool, chain::Error> {
 		Ok(false)
+	}
+
+	fn txhashset_download_fail(&self, _fail_reason: String) {
+		unimplemented!()
 	}
 
 	fn txhashset_download_update(

--- a/p2p/src/types.rs
+++ b/p2p/src/types.rs
@@ -580,6 +580,10 @@ pub trait ChainAdapter: Sync + Send {
 	/// state data.
 	fn txhashset_receive_ready(&self) -> bool;
 
+	/// Notify the sync thread the txhashset download has failed, so as to restart
+	/// a new downloading request.
+	fn txhashset_download_fail(&self, fail_reason: String);
+
 	/// Update txhashset downloading progress
 	fn txhashset_download_update(
 		&self,

--- a/servers/src/common/adapters.rs
+++ b/servers/src/common/adapters.rs
@@ -393,6 +393,13 @@ impl p2p::ChainAdapter for NetToChainAdapter {
 		}
 	}
 
+	fn txhashset_download_fail(&self, fail_reason: String) {
+		self.sync_state.set_sync_error(
+			chain::ErrorKind::TxHashSetErr(format!("txhashset download failed: {}", fail_reason))
+				.into(),
+		);
+	}
+
 	fn txhashset_download_update(
 		&self,
 		start_time: DateTime<Utc>,


### PR DESCRIPTION
In state sync stage, if the txhashset download fail, we have to wait a `10 minutes` timeout before restarting a new request.

```sh
20191204 09:10:01.289 DEBUG gotts_p2p::protocol - handle_payload: txhashset archive for 046b17883ff0 at 2010. size=1048516
20191204 09:10:12.356 DEBUG gotts_p2p::protocol - handle_payload: txhashset archive: 528000/1048516
20191204 09:10:13.367 ERROR gotts_p2p::protocol - handle_payload: txhashset archive save to file fail. err=Connection(Os { code: 11, kind: WouldBlock, message: "Resource temporarily unavailable" })
```

This PR can notify this failure and cause the sync thread restart a new request immediately.

---

Another possible improvement is to explicitly move the accepted TCP stream into blocking mode, which is found in https://github.com/mimblewimble/grin/pull/3154 and should be helpful to avoid above failure.

Leave a TODO item here to check what's the perfect way to set this `non-blocking` / `blocking`:
```Rust
	/// Starts a new TCP server and listen to incoming connections.
	pub fn listen(&self) -> Result<(), Error> {
		...
		listener.set_nonblocking(true)?;
		...
		loop {
			...
			match listener.accept() {
				Ok((stream, peer_addr)) => {
					// Explicitly move the accepted TCP stream into blocking mode.
					stream.set_nonblocking(false)?;
```

