### PR TITLE
refact: use last path instead of key id to shorten the PathMessage

### DIFF
--- a/chain/tests/chain_test_helper.rs
+++ b/chain/tests/chain_test_helper.rs
@@ -23,7 +23,7 @@ use self::core::genesis;
 use self::core::global::ChainTypes;
 use self::core::libtx::{self, reward};
 use self::core::{consensus, global, pow};
-use self::keychain::{ExtKeychainPath, Keychain};
+use self::keychain::{ExtKeychainPath, Identifier, Keychain};
 use self::util::RwLock;
 use chrono::Duration;
 use gotts_chain as chain;
@@ -59,7 +59,7 @@ where
 	let key_id = keychain::ExtKeychain::derive_key_id(0, 1, 0, 0, 0);
 	let reward = reward::output(
 		keychain,
-		&libtx::ProofBuilder::new(keychain),
+		&libtx::ProofBuilder::new(keychain, &Identifier::zero()),
 		&key_id,
 		0,
 		false,
@@ -88,9 +88,14 @@ where
 		let prev = chain.head_header().unwrap();
 		let next_header_info = consensus::next_difficulty(1, chain.difficulty_iter().unwrap());
 		let pk = ExtKeychainPath::new(1, n as u32, 0, 0, 0).to_identifier();
-		let reward =
-			libtx::reward::output(keychain, &libtx::ProofBuilder::new(keychain), &pk, 0, false)
-				.unwrap();
+		let reward = libtx::reward::output(
+			keychain,
+			&libtx::ProofBuilder::new(keychain, &Identifier::zero()),
+			&pk,
+			0,
+			false,
+		)
+		.unwrap();
 		let mut b =
 			core::core::Block::new(&prev, vec![], next_header_info.clone().difficulty, reward)
 				.unwrap();

--- a/chain/tests/test_coinbase_maturity.rs
+++ b/chain/tests/test_coinbase_maturity.rs
@@ -20,7 +20,7 @@ use self::core::global::{self, ChainTypes};
 use self::core::libtx::{self, build, ProofBuilder};
 use self::core::pow::Difficulty;
 use self::core::{consensus, pow};
-use self::keychain::{ExtKeychain, ExtKeychainPath, Keychain};
+use self::keychain::{ExtKeychain, ExtKeychainPath, Identifier, Keychain};
 use self::util::RwLock;
 use chrono::Duration;
 use env_logger;
@@ -61,7 +61,7 @@ fn test_coinbase_maturity() {
 		let prev = chain.head_header().unwrap();
 
 		let keychain = ExtKeychain::from_random_seed(false).unwrap();
-		let builder = ProofBuilder::new(&keychain);
+		let builder = ProofBuilder::new(&keychain, &Identifier::zero());
 		let key_id1 = ExtKeychainPath::new(1, 1, 0, 0, 0).to_identifier();
 		let key_id2 = ExtKeychainPath::new(1, 2, 0, 0, 0).to_identifier();
 		let key_id3 = ExtKeychainPath::new(1, 3, 0, 0, 0).to_identifier();
@@ -145,7 +145,7 @@ fn test_coinbase_maturity() {
 			let prev = chain.head_header().unwrap();
 
 			let keychain = ExtKeychain::from_random_seed(false).unwrap();
-			let builder = ProofBuilder::new(&keychain);
+			let builder = ProofBuilder::new(&keychain, &Identifier::zero());
 			let key_id1 = ExtKeychainPath::new(1, 1, 0, 0, 0).to_identifier();
 
 			let next_header_info = consensus::next_difficulty(1, chain.difficulty_iter().unwrap());
@@ -228,7 +228,7 @@ fn test_coinbase_maturity() {
 				let prev = chain.head_header().unwrap();
 
 				let keychain = ExtKeychain::from_random_seed(false).unwrap();
-				let builder = ProofBuilder::new(&keychain);
+				let builder = ProofBuilder::new(&keychain, &Identifier::zero());
 				let pk = ExtKeychainPath::new(1, 1, 0, 0, 0).to_identifier();
 
 				let reward = libtx::reward::output(&keychain, &builder, &pk, 0, false).unwrap();

--- a/core/src/genesis.rs
+++ b/core/src/genesis.rs
@@ -51,13 +51,13 @@ pub fn genesis_dev() -> core::Block {
 pub fn genesis_floo() -> core::Block {
 	let gen = core::Block::with_header(core::BlockHeader {
 		height: 0,
-		timestamp: Utc.ymd(2019, 11, 19).and_hms(11, 5, 57),
+		timestamp: Utc.ymd(2019, 12, 6).and_hms(10, 10, 37),
 		prev_root: Hash::from_hex(
-			"000000000000000000144fd714bfd4ce8d1d4c144e2b16f6159a9917b1570732",
+			"00000000000000000001d9e109f3d6803d7fd5d2140c7ee75258289cc0a8c9dd",
 		)
 		.unwrap(),
 		output_i_root: Hash::from_hex(
-			"8233a3826ac81c5077b01e558aef183ff23e7f4df378276b3f1eeef31b9456b6",
+			"6a996c4bc4498869720a2011f0f5e4e1448c5f69c4e536746019dc198cc99c86",
 		)
 		.unwrap(),
 		output_ii_root: Hash::from_hex(
@@ -65,7 +65,7 @@ pub fn genesis_floo() -> core::Block {
 		)
 		.unwrap(),
 		kernel_root: Hash::from_hex(
-			"fda7320458bec205a2d79de0587d0d8b6c7fdcfa1ebb44128e937662a0d26480",
+			"a7a1066efbdb7c11b308c19c061a5dd3aff71f52a9a5d0b18c89584e1e6fcf74",
 		)
 		.unwrap(),
 		output_i_mmr_size: 1,
@@ -74,15 +74,15 @@ pub fn genesis_floo() -> core::Block {
 		pow: ProofOfWork {
 			total_difficulty: Difficulty::from_num(10_u64.pow(3)),
 			secondary_scaling: 1856,
-			nonce: 10,
+			nonce: 7,
 			proof: Proof {
 				nonces: vec![
-					10041868, 10081004, 27450470, 30164461, 31309253, 52957945, 75520034,
-					149472619, 155698073, 165023110, 169406003, 201178374, 202536961, 206955939,
-					207173826, 207796956, 222586000, 224836028, 236552375, 250069741, 260260498,
-					282179934, 286454758, 303922880, 314959757, 323525307, 331775582, 338127072,
-					347103743, 348610726, 386218307, 409319759, 441701070, 458441174, 477235510,
-					481919117, 493460028, 500169831, 504263775, 508591322, 512244144, 531391596,
+					3693091, 6647809, 8167299, 18449581, 29988755, 76085502, 98400296, 107591918,
+					130175155, 150750946, 153604229, 171111155, 202813214, 210108053, 260775114,
+					282146891, 289372347, 291460826, 295067268, 296005855, 306472220, 307181476,
+					328933928, 361202447, 371668337, 408860544, 420398904, 421354254, 423031020,
+					426206487, 433328203, 437600629, 438818352, 444188167, 445824717, 447764188,
+					479576377, 484019713, 498562620, 508206041, 521593429, 524134681,
 				],
 				edge_bits: 29,
 			},
@@ -92,15 +92,12 @@ pub fn genesis_floo() -> core::Block {
 	let kernel = core::TxKernel {
 		features: core::KernelFeatures::Coinbase,
 		excess: Commitment::from_vec(util::from_hex("098364706891b414a55a91ef8686c51ec70d4b779052977009f625630e17a2f1c3".to_string()).unwrap()),
-		excess_sig: Signature::from_compact(&util::from_hex("0310ae8f5acaede5ebd62cef36a4979eb7e2cb76cee071a47c3876c1976f0b8373ece849ccaee9b23b0a8d29150d0e1df2bc9028cb80b956a3bef3299b9d369a".to_string()).unwrap()).unwrap(),
+		excess_sig: Signature::from_compact(&util::from_hex("aa2ebd4aa20557cd620d75d996683eecde521d77e72d7725fbbd85f141e7ce6b7c9c6f09fb2a4d94a38ddf444ff4ea6815ebf21ede63ad7a7f4d3fd8124eef77".to_string()).unwrap()).unwrap(),
 	};
 	let output = core::Output {
 		features: core::OutputFeaturesEx::Coinbase {
 			spath: SecuredPath::from_vec(
-				util::from_hex(
-					"bd3be4bdd2a8d4a7a8559bbcfb5e4705cec320d0ebc633eaaf403c46".to_string(),
-				)
-				.unwrap(),
+				util::from_hex("bd3be4bdd2a8d4a7a8559bbf".to_string()).unwrap(),
 			),
 		},
 		commit: Commitment::from_vec(
@@ -166,11 +163,11 @@ mod test {
 		println!("floonet genesis full hash: {}\n", gen_bin.hash().to_hex());
 		assert_eq!(
 			gen_hash.to_hex(),
-			"be9f27aa3e8facf0c37f7a0f654dc24c899460fbc7bbd076ffac936407aa2b0e"
+			"1ecf38f5cf17a2734d4bc26251ba990487e360103b46741c49acb685b8e41075"
 		);
 		assert_eq!(
 			gen_bin.hash().to_hex(),
-			"8dcab2576ccb50c76b6604d109224a74aed50a78011c854c5aa6825ca5260ea2"
+			"1ca3d80c48f409e0cc9de0d8382cb958f0b761ea9f5047e80906f48c50b73553"
 		);
 	}
 
@@ -186,7 +183,7 @@ mod test {
 		);
 		assert_eq!(
 			gen_bin.hash().to_hex(),
-			"be10ae6e874475bb29585a4997f8e42b5afe4ac3a131430036c93b5aaceefd3b"
+			"0a6d78ac2ef38ba9373a62e3dd1acde7236bd94d8d370af58755683245a0ad43"
 		);
 	}
 }

--- a/core/src/libtx/aggsig.rs
+++ b/core/src/libtx/aggsig.rs
@@ -232,7 +232,7 @@ pub fn verify_partial_sig(
 /// use core::libtx::{aggsig, proof};
 /// use core::core::transaction::KernelFeatures;
 /// use core::core::{Output, OutputFeaturesEx};
-/// use keychain::{Keychain, ExtKeychain};
+/// use keychain::{Keychain, Identifier, ExtKeychain};
 /// use rand::{thread_rng, Rng};
 ///
 /// let secp = Secp256k1::with_caps(ContextFlag::Commit);
@@ -242,7 +242,7 @@ pub fn verify_partial_sig(
 /// let key_id = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
 /// let w: i64 = thread_rng().gen();
 /// let commit = keychain.commit(w, &key_id).unwrap();
-/// let builder = proof::ProofBuilder::new(&keychain);
+/// let builder = proof::ProofBuilder::new(&keychain, &Identifier::zero());
 /// let spath = proof::create_secured_path(&keychain, &builder, w, &key_id, commit);
 /// let output = Output {
 ///		features: OutputFeaturesEx::Plain { spath },
@@ -301,7 +301,7 @@ where
 /// use util::secp::{ContextFlag, Secp256k1};
 /// use core::core::transaction::KernelFeatures;
 /// use core::core::{Output, OutputFeaturesEx};
-/// use keychain::{Keychain, ExtKeychain};
+/// use keychain::{Keychain, ExtKeychain, Identifier};
 /// use rand::{thread_rng, Rng};
 ///
 /// // Create signature
@@ -312,7 +312,7 @@ where
 /// let key_id = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
 /// let w = 0i64;
 /// let commit = keychain.commit(w, &key_id).unwrap();
-/// let builder = proof::ProofBuilder::new(&keychain);
+/// let builder = proof::ProofBuilder::new(&keychain, &Identifier::zero());
 /// let spath = proof::create_secured_path(&keychain, &builder, w, &key_id, commit);
 /// let output = Output {
 ///		features: OutputFeaturesEx::Coinbase { spath },

--- a/core/src/libtx/build.rs
+++ b/core/src/libtx/build.rs
@@ -435,7 +435,7 @@ mod test {
 	#[test]
 	fn blind_simple_tx() {
 		let keychain = ExtKeychain::from_random_seed(false).unwrap();
-		let builder = ProofBuilder::new(&keychain);
+		let builder = ProofBuilder::new(&keychain, &Identifier::zero());
 		let key_id1 = ExtKeychainPath::new(1, 1, 0, 0, 0).to_identifier();
 		let key_id2 = ExtKeychainPath::new(1, 2, 0, 0, 0).to_identifier();
 		let key_id3 = ExtKeychainPath::new(1, 3, 0, 0, 0).to_identifier();
@@ -493,7 +493,7 @@ mod test {
 	#[test]
 	fn blind_simpler_tx() {
 		let keychain = ExtKeychain::from_random_seed(false).unwrap();
-		let builder = ProofBuilder::new(&keychain);
+		let builder = ProofBuilder::new(&keychain, &Identifier::zero());
 		let key_id1 = ExtKeychainPath::new(1, 1, 0, 0, 0).to_identifier();
 		let key_id2 = ExtKeychainPath::new(1, 2, 0, 0, 0).to_identifier();
 

--- a/core/tests/common.rs
+++ b/core/tests/common.rs
@@ -31,7 +31,7 @@ use gotts_keychain::{Identifier, Keychain};
 // utility producing a transaction with 2 inputs and a single outputs
 pub fn tx2i1o() -> Transaction {
 	let keychain = keychain::ExtKeychain::from_random_seed(false).unwrap();
-	let builder = ProofBuilder::new(&keychain);
+	let builder = ProofBuilder::new(&keychain, &Identifier::zero());
 	let key_id1 = keychain::ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
 	let key_id2 = keychain::ExtKeychain::derive_key_id(1, 2, 0, 0, 0);
 	let key_id3 = keychain::ExtKeychain::derive_key_id(1, 3, 0, 0, 0);
@@ -52,7 +52,7 @@ pub fn tx2i1o() -> Transaction {
 // utility producing a transaction with a single input and output
 pub fn tx1i1o() -> Transaction {
 	let keychain = keychain::ExtKeychain::from_random_seed(false).unwrap();
-	let builder = ProofBuilder::new(&keychain);
+	let builder = ProofBuilder::new(&keychain, &Identifier::zero());
 	let key_id1 = keychain::ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
 	let key_id2 = keychain::ExtKeychain::derive_key_id(1, 2, 0, 0, 0);
 
@@ -73,7 +73,7 @@ pub fn tx1i1o() -> Transaction {
 // Note: this tx has an "offset" kernel
 pub fn tx1i2o() -> Transaction {
 	let keychain = keychain::ExtKeychain::from_random_seed(false).unwrap();
-	let builder = ProofBuilder::new(&keychain);
+	let builder = ProofBuilder::new(&keychain, &Identifier::zero());
 	let key_id1 = keychain::ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
 	let key_id2 = keychain::ExtKeychain::derive_key_id(1, 2, 0, 0, 0);
 	let key_id3 = keychain::ExtKeychain::derive_key_id(1, 3, 0, 0, 0);

--- a/core/tests/core.rs
+++ b/core/tests/core.rs
@@ -27,7 +27,7 @@ use self::core::libtx::build::{
 };
 use self::core::libtx::ProofBuilder;
 use self::core::ser;
-use self::keychain::{ExtKeychain, Keychain};
+use self::keychain::{ExtKeychain, Identifier, Keychain};
 use self::util::RwLock;
 use crate::common::{new_block, tx1i1o, tx1i2o, tx2i1o};
 use crate::util::secp::pedersen::Commitment;
@@ -43,14 +43,14 @@ fn simple_tx_ser() {
 	let tx = tx2i1o();
 	let mut vec = Vec::new();
 	ser::serialize_default(&mut vec, &tx).expect("serialization failed");
-	let target_len = 258;
+	let target_len = 242;
 	assert_eq!(vec.len(), target_len,);
 
 	let tx = tx1i2o();
 	println!("tx = {}", serde_json::to_string_pretty(&tx).unwrap());
 	let mut vec = Vec::new();
 	ser::serialize_default(&mut vec, &tx).expect("serialization failed");
-	let target_len = 293;
+	let target_len = 261;
 	println!("tx vec = {:02x?}", vec);
 	assert_eq!(vec.len(), target_len,);
 }
@@ -87,7 +87,7 @@ fn tx_double_ser_deser() {
 #[test]
 fn test_zero_commit_fails() {
 	let keychain = ExtKeychain::from_random_seed(false).unwrap();
-	let builder = ProofBuilder::new(&keychain);
+	let builder = ProofBuilder::new(&keychain, &Identifier::zero());
 	let key_id1 = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
 
 	// blinding should fail as signing with a zero r*G shouldn't work
@@ -109,7 +109,7 @@ fn verifier_cache() -> Arc<RwLock<dyn VerifierCache>> {
 #[test]
 fn build_tx_kernel() {
 	let keychain = ExtKeychain::from_random_seed(false).unwrap();
-	let builder = ProofBuilder::new(&keychain);
+	let builder = ProofBuilder::new(&keychain, &Identifier::zero());
 	let key_id1 = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
 	let key_id2 = ExtKeychain::derive_key_id(1, 2, 0, 0, 0);
 	let key_id3 = ExtKeychain::derive_key_id(1, 3, 0, 0, 0);
@@ -441,7 +441,7 @@ fn basic_transaction_deaggregation() {
 #[test]
 fn hash_output() {
 	let keychain = ExtKeychain::from_random_seed(false).unwrap();
-	let builder = ProofBuilder::new(&keychain);
+	let builder = ProofBuilder::new(&keychain, &Identifier::zero());
 	let key_id1 = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
 	let key_id2 = ExtKeychain::derive_key_id(1, 2, 0, 0, 0);
 	let key_id3 = ExtKeychain::derive_key_id(1, 3, 0, 0, 0);
@@ -486,7 +486,7 @@ fn tx_hash_diff() {
 #[test]
 fn tx_build_exchange() {
 	let keychain = ExtKeychain::from_random_seed(false).unwrap();
-	let builder = ProofBuilder::new(&keychain);
+	let builder = ProofBuilder::new(&keychain, &Identifier::zero());
 	let key_id1 = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
 	let key_id2 = ExtKeychain::derive_key_id(1, 2, 0, 0, 0);
 	let key_id3 = ExtKeychain::derive_key_id(1, 3, 0, 0, 0);
@@ -531,7 +531,7 @@ fn tx_build_exchange() {
 #[test]
 fn reward_empty_block() {
 	let keychain = keychain::ExtKeychain::from_random_seed(false).unwrap();
-	let builder = ProofBuilder::new(&keychain);
+	let builder = ProofBuilder::new(&keychain, &Identifier::zero());
 	let key_id = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
 
 	let previous_header = BlockHeader::default();
@@ -547,7 +547,7 @@ fn reward_empty_block() {
 #[test]
 fn reward_with_tx_block() {
 	let keychain = keychain::ExtKeychain::from_random_seed(false).unwrap();
-	let builder = ProofBuilder::new(&keychain);
+	let builder = ProofBuilder::new(&keychain, &Identifier::zero());
 	let key_id = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
 
 	let vc = verifier_cache();
@@ -575,7 +575,7 @@ fn reward_with_tx_block() {
 #[test]
 fn simple_block() {
 	let keychain = keychain::ExtKeychain::from_random_seed(false).unwrap();
-	let builder = ProofBuilder::new(&keychain);
+	let builder = ProofBuilder::new(&keychain, &Identifier::zero());
 	let key_id = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
 
 	let vc = verifier_cache();
@@ -598,7 +598,7 @@ fn simple_block() {
 #[test]
 fn test_block_with_timelocked_tx() {
 	let keychain = keychain::ExtKeychain::from_random_seed(false).unwrap();
-	let builder = ProofBuilder::new(&keychain);
+	let builder = ProofBuilder::new(&keychain, &Identifier::zero());
 	let key_id1 = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
 	let key_id2 = ExtKeychain::derive_key_id(1, 2, 0, 0, 0);
 	let key_id3 = ExtKeychain::derive_key_id(1, 3, 0, 0, 0);

--- a/core/tests/verifier_cache.rs
+++ b/core/tests/verifier_cache.rs
@@ -18,7 +18,7 @@ pub mod common;
 use self::core::core::verifier_cache::{LruVerifierCache, VerifierCache};
 use self::core::core::{Output, OutputFeaturesEx};
 use self::core::libtx::{build, proof};
-use self::keychain::{ExtKeychain, Keychain};
+use self::keychain::{ExtKeychain, Identifier, Keychain};
 use self::util::secp::PublicKey;
 use self::util::RwLock;
 use gotts_core as core;
@@ -37,7 +37,7 @@ fn test_verifier_cache_unlocker() {
 	let cache = verifier_cache();
 
 	let keychain = ExtKeychain::from_random_seed(false).unwrap();
-	let builder = proof::ProofBuilder::new(&keychain);
+	let builder = proof::ProofBuilder::new(&keychain, &Identifier::zero());
 
 	let key_id = ExtKeychain::derive_key_id(4, u32::MAX, u32::MAX, 0, 0);
 	let w: i64 = thread_rng().gen();

--- a/etc/gen_gen/src/bin/gen_gen.rs
+++ b/etc/gen_gen/src/bin/gen_gen.rs
@@ -33,7 +33,7 @@ use grin_miner_plugin as plugin;
 
 use gotts_core::core::hash::Hashed;
 use gotts_core::core::verifier_cache::LruVerifierCache;
-use gotts_keychain::{ExtKeychain, Keychain};
+use gotts_keychain::{ExtKeychain, Identifier, Keychain};
 
 use gotts_wallet_config::WalletConfig;
 use gotts_wallet_impls::WalletSeed;
@@ -89,7 +89,7 @@ fn main() {
 	)
 	.unwrap();
 	let keychain = ExtKeychain::from_seed(&seed.to_vec(), false).unwrap();
-	let builder = core::libtx::ProofBuilder::new(&keychain);
+	let builder = core::libtx::ProofBuilder::new(&keychain, &Identifier::zero());
 	let key_id = ExtKeychain::derive_key_id(3, 1, 0, 0, 0);
 	let reward = core::libtx::reward::output(&keychain, &builder, &key_id, 0, false).unwrap();
 	gen = gen.with_reward(reward.0, reward.1);
@@ -145,7 +145,7 @@ fn main() {
 	assert!(gen.header.pow.is_secondary(), "Not a secondary header");
 	println!("Built genesis:\n{:?}", gen);
 	core::pow::verify_size(&gen.header).unwrap();
-	gen.validate(Arc::new(util::RwLock::new(LruVerifierCache::new())))
+	gen.validate(Arc::new(util::RwLock::new(LruVerifierCache::new())), None)
 		.unwrap();
 
 	println!("\nFinal genesis cyclehash: {}", gen.hash().to_hex());

--- a/p2p/tests/peer_handshake.rs
+++ b/p2p/tests/peer_handshake.rs
@@ -19,6 +19,7 @@ use gotts_p2p as p2p;
 use gotts_util as util;
 use gotts_util::StopState;
 
+use std::fs;
 use std::net::{SocketAddr, TcpListener, TcpStream};
 use std::sync::Arc;
 use std::{thread, time};
@@ -36,11 +37,17 @@ fn open_port() -> u16 {
 	listener.local_addr().unwrap().port()
 }
 
+fn clean_output_dir(test_dir: &str) {
+	let _ = fs::remove_dir_all(test_dir);
+}
+
 // Starts a server and connects a client peer to it to check handshake,
 // followed by a ping/pong exchange to make sure the connection is live.
 #[test]
 fn peer_handshake() {
 	util::init_test_logger();
+	let test_dir = ".gotts";
+	clean_output_dir(test_dir);
 
 	let p2p_config = p2p::P2PConfig {
 		host: "127.0.0.1".parse().unwrap(),
@@ -92,4 +99,5 @@ fn peer_handshake() {
 	let server_peer = server.peers.get_connected_peer(my_addr).unwrap();
 	assert_eq!(server_peer.info.total_difficulty(), Difficulty::min());
 	assert!(server.peers.peer_count() > 0);
+	clean_output_dir(test_dir);
 }

--- a/pool/tests/block_building.rs
+++ b/pool/tests/block_building.rs
@@ -20,7 +20,7 @@ use self::core::core::verifier_cache::LruVerifierCache;
 use self::core::core::{Block, BlockHeader, Transaction};
 use self::core::libtx;
 use self::core::pow::Difficulty;
-use self::keychain::{ExtKeychain, Keychain};
+use self::keychain::{ExtKeychain, Identifier, Keychain};
 use self::pool::types::PoolError;
 use self::util::RwLock;
 use crate::common::*;
@@ -52,7 +52,7 @@ fn test_transaction_pool_block_building() {
 				let fee = txs.iter().map(|x| x.fee()).sum();
 				let reward = libtx::reward::output(
 					&keychain,
-					&libtx::ProofBuilder::new(&keychain),
+					&libtx::ProofBuilder::new(&keychain, &Identifier::zero()),
 					&key_id,
 					fee,
 					false,

--- a/pool/tests/block_max_weight.rs
+++ b/pool/tests/block_max_weight.rs
@@ -23,7 +23,7 @@ use self::core::core::{Block, BlockHeader, Transaction};
 use self::core::global;
 use self::core::libtx;
 use self::core::pow::Difficulty;
-use self::keychain::{ExtKeychain, Keychain};
+use self::keychain::{ExtKeychain, Identifier, Keychain};
 use self::util::RwLock;
 use crate::common::*;
 use gotts_core as core;
@@ -54,7 +54,7 @@ fn test_block_building_max_weight() {
 				let fee = txs.iter().map(|x| x.fee()).sum();
 				let reward = libtx::reward::output(
 					&keychain,
-					&libtx::ProofBuilder::new(&keychain),
+					&libtx::ProofBuilder::new(&keychain, &Identifier::zero()),
 					&key_id,
 					fee,
 					false,

--- a/pool/tests/block_reconciliation.rs
+++ b/pool/tests/block_reconciliation.rs
@@ -20,7 +20,7 @@ use self::core::core::verifier_cache::LruVerifierCache;
 use self::core::core::{Block, BlockHeader};
 use self::core::libtx;
 use self::core::pow::Difficulty;
-use self::keychain::{ExtKeychain, Keychain};
+use self::keychain::{ExtKeychain, Identifier, Keychain};
 use self::util::RwLock;
 use crate::common::ChainAdapter;
 use crate::common::*;
@@ -48,7 +48,7 @@ fn test_transaction_pool_block_reconciliation() {
 			let key_id = ExtKeychain::derive_key_id(1, height as u32, 0, 0, 0);
 			let reward = libtx::reward::output(
 				&keychain,
-				&libtx::ProofBuilder::new(&keychain),
+				&libtx::ProofBuilder::new(&keychain, &Identifier::zero()),
 				&key_id,
 				0,
 				false,
@@ -75,7 +75,7 @@ fn test_transaction_pool_block_reconciliation() {
 			let fees = initial_tx.fee();
 			let reward = libtx::reward::output(
 				&keychain,
-				&libtx::ProofBuilder::new(&keychain),
+				&libtx::ProofBuilder::new(&keychain, &Identifier::zero()),
 				&key_id,
 				fees,
 				false,
@@ -176,7 +176,7 @@ fn test_transaction_pool_block_reconciliation() {
 			let fees = block_txs.iter().map(|tx| tx.fee()).sum();
 			let reward = libtx::reward::output(
 				&keychain,
-				&libtx::ProofBuilder::new(&keychain),
+				&libtx::ProofBuilder::new(&keychain, &Identifier::zero()),
 				&key_id,
 				fees,
 				false,

--- a/pool/tests/common.rs
+++ b/pool/tests/common.rs
@@ -21,7 +21,7 @@ use self::core::core::hash::{Hash, Hashed};
 use self::core::core::verifier_cache::VerifierCache;
 use self::core::core::{Block, BlockHeader, BlockSums, Committed, Input, OutputEx, Transaction};
 use self::core::libtx;
-use self::keychain::{ExtKeychain, Keychain};
+use self::keychain::{ExtKeychain, Identifier, Keychain};
 use self::pool::types::*;
 use self::pool::TransactionPool;
 use self::util::secp::pedersen::Commitment;
@@ -229,7 +229,12 @@ where
 
 	tx_elements.push(libtx::build::with_fee(fees as u64));
 
-	libtx::build::transaction(tx_elements, keychain, &libtx::ProofBuilder::new(keychain)).unwrap()
+	libtx::build::transaction(
+		tx_elements,
+		keychain,
+		&libtx::ProofBuilder::new(keychain, &Identifier::zero()),
+	)
+	.unwrap()
 }
 
 pub fn test_transaction<K>(
@@ -259,7 +264,12 @@ where
 	}
 	tx_elements.push(libtx::build::with_fee(fees as u64));
 
-	libtx::build::transaction(tx_elements, keychain, &libtx::ProofBuilder::new(keychain)).unwrap()
+	libtx::build::transaction(
+		tx_elements,
+		keychain,
+		&libtx::ProofBuilder::new(keychain, &Identifier::zero()),
+	)
+	.unwrap()
 }
 
 pub fn test_bad_transaction<K>(
@@ -290,7 +300,12 @@ where
 	}
 	tx_elements.push(libtx::build::with_fee(fees as u64));
 
-	libtx::build::transaction(tx_elements, keychain, &libtx::ProofBuilder::new(keychain)).unwrap()
+	libtx::build::transaction(
+		tx_elements,
+		keychain,
+		&libtx::ProofBuilder::new(keychain, &Identifier::zero()),
+	)
+	.unwrap()
 }
 
 pub fn test_source() -> TxSource {

--- a/pool/tests/transaction_pool.rs
+++ b/pool/tests/transaction_pool.rs
@@ -19,7 +19,7 @@ use self::core::core::verifier_cache::LruVerifierCache;
 use self::core::core::{transaction, Block, BlockHeader, Weighting};
 use self::core::libtx;
 use self::core::pow::Difficulty;
-use self::keychain::{ExtKeychain, Keychain};
+use self::keychain::{ExtKeychain, Identifier, Keychain};
 use self::pool::TxSource;
 use self::util::RwLock;
 use crate::common::*;
@@ -50,7 +50,7 @@ fn test_the_transaction_pool() {
 		let key_id = ExtKeychain::derive_key_id(1, height as u32, 0, 0, 0);
 		let reward = libtx::reward::output(
 			&keychain,
-			&libtx::ProofBuilder::new(&keychain),
+			&libtx::ProofBuilder::new(&keychain, &Identifier::zero()),
 			&key_id,
 			0,
 			false,
@@ -264,7 +264,7 @@ fn test_the_transaction_pool() {
 			let key_id = ExtKeychain::derive_key_id(1, height as u32, 0, 0, 0);
 			let reward = libtx::reward::output(
 				&keychain,
-				&libtx::ProofBuilder::new(&keychain),
+				&libtx::ProofBuilder::new(&keychain, &Identifier::zero()),
 				&key_id,
 				0,
 				false,

--- a/servers/src/mining/mine_block.rs
+++ b/servers/src/mining/mine_block.rs
@@ -229,7 +229,7 @@ fn burn_reward(block_fees: BlockFees) -> Result<(core::Output, core::TxKernel, B
 	let key_id = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
 	let (out, kernel) = crate::core::libtx::reward::output(
 		&keychain,
-		&ProofBuilder::new(&keychain),
+		&ProofBuilder::new(&keychain, &key_id),
 		&key_id,
 		block_fees.fees,
 		false,

--- a/store/tests/lmdb.rs
+++ b/store/tests/lmdb.rs
@@ -99,6 +99,7 @@ fn lmdb_allocate() -> Result<(), store::Error> {
 			batch.commit()?;
 		}
 	}
+	clean_output_dir(test_dir);
 
 	Ok(())
 }


### PR DESCRIPTION
The current `PathMessage` contains 28 bytes as follows:
```Rust
struct PathMessage {
	/// Reserved at this moment.
	reserved: [u8; 3],
	/// The random 'w' of Pedersen commitment `r*G + w*H`.
	w: u64,
	/// The key identifier. 1-byte path depth and 16-bytes BIP-32 key derivation path.
	key_id: Identifier,
}
```

The complete `Identifier` here is a little bit wasting on the precious chain space, this PR shorten the `key_id` here, replace it with the `last_path` which is only 4 bytes instead of 17 bytes.
```Rust
pub struct PathMessage {
	/// The random 'w' of Pedersen commitment `r*G + w*H`
	pub w: i64,
	/// The last path index of the key identifier
	pub key_id_last_path: u32,
}
```

This is a balance we have to make, between a compact chain space and a simpler wallet implementation. The new `PathMessage` only need 12 bytes.

For wallet restoring or checking, to get a complete key id, the wallet must know the parent key path, which should be bound to the wallet account (i.e. `m/p1/p2`).

For example the `default` wallet account:
```sh
$ gotts-wallet --floonet account

____ Wallet Accounts ____

 Name    | Parent BIP-32 Derivation Path 
---------+-------------------------------
 default | m/0/0 
```

After this PR, the wallet will never be able to restore all coins by one call, since a wallet could have multiple wallet accounts. It will have to leave to the wallet user to manage the wallet accounts manually, but I think it's acceptable, considering the original intention of the "accounts".

**Additional note**:
At maximum, a Gotts key id (i.e `Identifier`) can have 4-level BIP-32 derivation path:  `m/p1/p2/p3/p4`. The 1st two path consist of the so-called wallet account here. The last path can be saved into the chain into the `PathMessage` here. Then, how about the 3rd path?

At this moment, let's leave a TODO here about this 3rd path. In my current design (including some refactoring on this part soon), I just leave this 3rd path always as `0`. This 3rd path could be used in the future if there's a good use case, but since we already have `2^31` keys here for each `m/p1/p2/0`, it's already fair enough for most of the use cases.

(Because this PR is a consensus breaking change, I also import a new Genesis block for Floonet test.)

