### PR TITLE
consensus: use 32bit fee instead of 64bit

### DIFF
--- a/core/src/core/hash.rs
+++ b/core/src/core/hash.rs
@@ -281,5 +281,6 @@ impl<D: DefaultHashable, E: DefaultHashable, F: DefaultHashable> DefaultHashable
 impl DefaultHashable for crate::util::secp::pedersen::RangeProof {}
 impl DefaultHashable for Vec<u8> {}
 impl DefaultHashable for u8 {}
+impl DefaultHashable for u32 {}
 impl DefaultHashable for u64 {}
 impl DefaultHashable for i64 {}

--- a/core/src/libtx/build.rs
+++ b/core/src/libtx/build.rs
@@ -288,7 +288,7 @@ where
 }
 
 /// Sets the fee on the transaction being built.
-pub fn with_fee<K, B>(fee: u64) -> Box<Append<K, B>>
+pub fn with_fee<K, B>(fee: u32) -> Box<Append<K, B>>
 where
 	K: Keychain,
 	B: ProofBuild,

--- a/core/tests/block.rs
+++ b/core/tests/block.rs
@@ -278,7 +278,7 @@ fn block_single_tx_serialized_size() {
 	let b = new_block(vec![&tx1], &keychain, &builder, &prev, &key_id);
 	let mut vec = Vec::new();
 	ser::serialize_default(&mut vec, &b).expect("serialization failed");
-	let target_len = 646;
+	let target_len = 642;
 	assert_eq!(vec.len(), target_len);
 }
 
@@ -329,7 +329,7 @@ fn block_10_tx_serialized_size() {
 	let b = new_block(txs.iter().collect(), &keychain, &builder, &prev, &key_id);
 	let mut vec = Vec::new();
 	ser::serialize_default(&mut vec, &b).expect("serialization failed");
-	let target_len = 2_887;
+	let target_len = 2_847;
 	assert_eq!(vec.len(), target_len,);
 }
 

--- a/core/tests/core.rs
+++ b/core/tests/core.rs
@@ -43,14 +43,14 @@ fn simple_tx_ser() {
 	let tx = tx2i1o();
 	let mut vec = Vec::new();
 	ser::serialize_default(&mut vec, &tx).expect("serialization failed");
-	let target_len = 242;
+	let target_len = 238;
 	assert_eq!(vec.len(), target_len,);
 
 	let tx = tx1i2o();
 	println!("tx = {}", serde_json::to_string_pretty(&tx).unwrap());
 	let mut vec = Vec::new();
 	ser::serialize_default(&mut vec, &tx).expect("serialization failed");
-	let target_len = 261;
+	let target_len = 257;
 	println!("tx vec = {:02x?}", vec);
 	assert_eq!(vec.len(), target_len,);
 }

--- a/keychain/src/types.rs
+++ b/keychain/src/types.rs
@@ -135,6 +135,10 @@ impl Identifier {
 		ExtKeychainPath::from_identifier(&self)
 	}
 
+	pub fn extend(&self, d: u32) -> Identifier {
+		self.to_path().extend(d).to_identifier()
+	}
+
 	pub fn to_value_path(&self, value: u64, w: i64) -> ValueExtKeychainPath {
 		ValueExtKeychainPath {
 			value,

--- a/pool/tests/common.rs
+++ b/pool/tests/common.rs
@@ -207,12 +207,11 @@ pub fn test_transaction_spending_coinbase<K>(
 where
 	K: Keychain,
 {
-	let output_sum = output_values.iter().sum::<u64>() as i64;
+	let output_sum = output_values.iter().sum::<u64>();
 
 	let coinbase_reward: u64 = 60_000_000_000;
 
-	let fees: i64 = coinbase_reward as i64 - output_sum;
-	assert!(fees >= 0);
+	let fees = coinbase_reward - output_sum;
 
 	let mut tx_elements = Vec::new();
 
@@ -227,7 +226,7 @@ where
 		tx_elements.push(libtx::build::output(output_value, Some(0i64), key_id));
 	}
 
-	tx_elements.push(libtx::build::with_fee(fees as u64));
+	tx_elements.push(libtx::build::with_fee(fees as u32));
 
 	libtx::build::transaction(
 		tx_elements,
@@ -245,11 +244,10 @@ pub fn test_transaction<K>(
 where
 	K: Keychain,
 {
-	let input_sum = input_values.iter().sum::<u64>() as i64;
-	let output_sum = output_values.iter().sum::<u64>() as i64;
+	let input_sum = input_values.iter().sum::<u64>();
+	let output_sum = output_values.iter().sum::<u64>();
 
-	let fees: i64 = input_sum - output_sum;
-	assert!(fees >= 0);
+	let fees = input_sum - output_sum;
 
 	let mut tx_elements = Vec::new();
 
@@ -262,7 +260,7 @@ where
 		let key_id = ExtKeychain::derive_key_id(1, output_value as u32, 0, 0, 0);
 		tx_elements.push(libtx::build::output(output_value, Some(0i64), key_id));
 	}
-	tx_elements.push(libtx::build::with_fee(fees as u64));
+	tx_elements.push(libtx::build::with_fee(fees as u32));
 
 	libtx::build::transaction(
 		tx_elements,
@@ -280,11 +278,10 @@ pub fn test_bad_transaction<K>(
 where
 	K: Keychain,
 {
-	let input_sum = input_values.iter().sum::<u64>() as i64;
-	let output_sum = output_values.iter().sum::<u64>() as i64;
+	let input_sum = input_values.iter().sum::<u64>();
+	let output_sum = output_values.iter().sum::<u64>();
 
-	let fees: i64 = input_sum - output_sum;
-	assert!(fees >= 0);
+	let fees = input_sum - output_sum;
 
 	let mut tx_elements = Vec::new();
 
@@ -298,7 +295,7 @@ where
 		// output_value + 1 here is a bad output value which has an inflation!
 		tx_elements.push(libtx::build::output(output_value + 1, Some(0i64), key_id));
 	}
-	tx_elements.push(libtx::build::with_fee(fees as u64));
+	tx_elements.push(libtx::build::with_fee(fees as u32));
 
 	libtx::build::transaction(
 		tx_elements,

--- a/pool/tests/transaction_pool.rs
+++ b/pool/tests/transaction_pool.rs
@@ -69,7 +69,19 @@ fn test_the_transaction_pool() {
 		test_transaction_spending_coinbase(
 			&keychain,
 			&header,
-			vec![500, 600, 700, 800, 900, 1000, 1100, 1200, 1300, 1400],
+			vec![
+				500,
+				600,
+				700,
+				800,
+				900,
+				1000,
+				1100,
+				1200,
+				1300,
+				1400,
+				59_000_000_000,
+			],
 		)
 	};
 
@@ -284,7 +296,19 @@ fn test_the_transaction_pool() {
 			test_transaction_spending_coinbase(
 				&keychain,
 				&header,
-				vec![500, 600, 700, 800, 900, 1000, 1100, 1200, 1300, 1400],
+				vec![
+					500,
+					600,
+					700,
+					800,
+					900,
+					1000,
+					1100,
+					1200,
+					1300,
+					1400,
+					59_000_000_000,
+				],
 			)
 		};
 

--- a/store/tests/pmmr.rs
+++ b/store/tests/pmmr.rs
@@ -1012,7 +1012,7 @@ fn variable_setup(tag: &str) -> (String, Vec<TestVariableElem>) {
 			1 => KernelFeatures::Plain { fee: x },
 			2 => KernelFeatures::HeightLocked {
 				fee: x,
-				lock_height: 100 + x,
+				lock_height: 100u64 + x as u64,
 			},
 			_ => KernelFeatures::Coinbase,
 		};


### PR DESCRIPTION
Currently the transaction fee is using 64-bit, but actually it's impractical to get one huge transaction with the `fee > 2^32`, which could need over `4,000` outputs for Grin or over `40,000` outputs for Gotts.

Let's change it to 32-bit, to save a little space in the chain.