### PR TITLE
refact: share the SecuredPath structure for OutputLocker

### DIFF
--- a/chain/src/txhashset/utxo_view.rs
+++ b/chain/src/txhashset/utxo_view.rs
@@ -131,7 +131,7 @@ impl<'a> UTXOView<'a> {
 	// Input is valid if it is spending an (unspent) output
 	// that currently exists in the output MMR.
 	// Compare the hash in the output MMR at the expected pos.
-	fn validate_input(&self, input: &Input, next_block_height: u64) -> Result<u64, Error> {
+	fn validate_input(&self, input: &Input, _next_block_height: u64) -> Result<u64, Error> {
 		if let Ok(ofph) = self.batch.get_output_pos_height(&input.commitment()) {
 			match ofph.features {
 				OutputFeatures::Plain | OutputFeatures::Coinbase => {
@@ -151,18 +151,7 @@ impl<'a> UTXOView<'a> {
 							if hash == output.hash_with_index(ofph.position - 1)
 								&& output.id.commit == input.commit
 							{
-								// Find the "cutoff" height.
-								let cutoff_height = next_block_height
-									.checked_sub(output.locker.relative_lock_height as u64)
-									.unwrap_or(0);
-
-								// If input height exceed the cutoff_height
-								// we know they have not yet sufficiently matured.
-								if ofph.height > cutoff_height {
-									return Err(ErrorKind::ImmatureCoinbase.into());
-								} else {
-									return Ok(output.value);
-								}
+								return Ok(output.value);
 							}
 						}
 					}

--- a/chain/tests/mine_simple_chain.rs
+++ b/chain/tests/mine_simple_chain.rs
@@ -590,7 +590,6 @@ fn spend_in_fork_and_compact() {
 		assert_eq!(tx1_ofph.position == 8 || tx1_ofph.position == 9, true);
 		let active_key_id = key_id30.parent_path();
 		let out1_path_msg = proof::rewind(
-			kc.secp(),
 			&pb,
 			&active_key_id,
 			&out1.commit,

--- a/core/src/libtx/aggsig.rs
+++ b/core/src/libtx/aggsig.rs
@@ -243,7 +243,7 @@ pub fn verify_partial_sig(
 /// let w: i64 = thread_rng().gen();
 /// let commit = keychain.commit(w, &key_id).unwrap();
 /// let builder = proof::ProofBuilder::new(&keychain, &Identifier::zero());
-/// let spath = proof::create_secured_path(&keychain, &builder, w, &key_id, commit);
+/// let spath = proof::create_secured_path(&builder, w, &key_id, commit);
 /// let output = Output {
 ///		features: OutputFeaturesEx::Plain { spath },
 ///		commit,
@@ -313,7 +313,7 @@ where
 /// let w = 0i64;
 /// let commit = keychain.commit(w, &key_id).unwrap();
 /// let builder = proof::ProofBuilder::new(&keychain, &Identifier::zero());
-/// let spath = proof::create_secured_path(&keychain, &builder, w, &key_id, commit);
+/// let spath = proof::create_secured_path(&builder, w, &key_id, commit);
 /// let output = Output {
 ///		features: OutputFeaturesEx::Coinbase { spath },
 ///		commit,

--- a/core/src/libtx/build.rs
+++ b/core/src/libtx/build.rs
@@ -225,8 +225,7 @@ where
 
 			debug!("Building output: {}, {:?}", value, commit);
 
-			let spath =
-				proof::create_secured_path(build.keychain, build.builder, w, &key_id, commit);
+			let spath = proof::create_secured_path(build.builder, w, &key_id, commit);
 
 			(
 				tx.with_output(Output {

--- a/core/src/libtx/reward.rs
+++ b/core/src/libtx/reward.rs
@@ -41,7 +41,7 @@ where
 
 	trace!("Block reward - Pedersen Commit is: {:?}", commit,);
 
-	let spath = proof::create_secured_path(keychain, builder, w, &key_id, commit);
+	let spath = proof::create_secured_path(builder, w, &key_id, commit);
 
 	let output = Output {
 		features: OutputFeaturesEx::Coinbase { spath },

--- a/core/tests/transaction.rs
+++ b/core/tests/transaction.rs
@@ -41,7 +41,7 @@ fn test_output_ser_deser() {
 	let w: i64 = thread_rng().gen();
 	let commit = keychain.commit(w, &key_id).unwrap();
 	let builder = proof::ProofBuilder::new(&keychain, &Identifier::zero());
-	let spath = proof::create_secured_path(&keychain, &builder, w, &key_id, commit);
+	let spath = proof::create_secured_path(&builder, w, &key_id, commit);
 
 	let out = Output {
 		features: OutputFeaturesEx::Plain { spath },
@@ -68,7 +68,7 @@ fn test_output_std_hash() {
 	let w: i64 = 100;
 	let commit = keychain.commit(w, &key_id).unwrap();
 	let builder = proof::ProofBuilder::new(&keychain, &Identifier::zero());
-	let spath = proof::create_secured_path(&keychain, &builder, w, &key_id, commit);
+	let spath = proof::create_secured_path(&builder, w, &key_id, commit);
 
 	let out = Output {
 		features: OutputFeaturesEx::Plain { spath },
@@ -125,7 +125,7 @@ fn test_output_std_hash() {
 
 	let mut hasher = DefaultHasher::new();
 	out_ii.hash(&mut hasher);
-	assert_eq!("d506ab1940606574", format!("{:x}", hasher.finish()));
+	assert_eq!("79e8cf86e3d2ea65", format!("{:x}", hasher.finish()));
 }
 
 #[test]
@@ -137,7 +137,7 @@ fn test_output_blake2b_hash() {
 	let w: i64 = 100;
 	let commit = keychain.commit(w, &key_id).unwrap();
 	let builder = proof::ProofBuilder::new(&keychain, &Identifier::zero());
-	let spath = proof::create_secured_path(&keychain, &builder, w, &key_id, commit);
+	let spath = proof::create_secured_path(&builder, w, &key_id, commit);
 
 	let out = Output {
 		features: OutputFeaturesEx::Plain { spath },
@@ -191,7 +191,7 @@ fn test_output_blake2b_hash() {
 	);
 	assert_eq!(
 		vec_ii.hash().to_hex(),
-		"4504a1f255a39cd67de0a56ec8fc4abe6f8556451399b62a7c3a466884d9a3d0",
+		"d14fd338c6aab88e1b848e692950684454c44cb4bc6ce73ea9cd46df9b3cb9e9",
 	);
 }
 


### PR DESCRIPTION
Refactoring the `OutputLocker` structure.

The original structure:
```Rust
struct OutputLocker {
	/// The Hash of 'Pay-to-Public-Key-Hash'.
	p2pkh: Hash,
	/// The 'R' for ephemeral key: `q = Hash(secured_w || p*R)`.
	pub_nonce: PublicKey,
	/// The secured version of 'w' for the Pedersen commitment: `C = q*G + w*H`,
	/// the real 'w' can be calculated by: `w = secured_w XOR q[0..8]`.
	secured_w: u64,
	/// The relative lock height, after which the output can be spent.
	relative_lock_height: u32,
}
```

The new structure:
```Rust
pub struct OutputLocker {
	/// The Blake2b hash of 'Pay-to-Public-Key-Hash'.
	pub p2pkh: Hash,
	/// The 'R' for ephemeral key: `q = Hash(secured_w || p*R)`.
	pub pub_nonce: PublicKey,
	/// A secured path message which hide the key derivation path and the random w of commitment.
	pub spath: SecuredPath,
}
```

The `PathMessage` structure:
```Rust
pub struct PathMessage {
	/// The random 'w' of Pedersen commitment `r*G + w*H`
	pub w: i64,
	/// The last path index of the key identifier
	pub key_id_last_path: u32,
}
```

Regarding the `relative_lock_height`:
- `relative_lock_height` is removed and take it always as value `1`.
- `relative_lock_height` 's 4-byte is replaced by `key_id_last_path` which is part of the `PathMessage` structure.

This refactoring is making the code more simple and better readable, and the new `key_id_last_path` will be helpful for wallet to check/restore all non-interactive outputs under one wallet account.


