### PR TITLE
refact: move 'RecipientKey' structure from node to wallet

### DIFF
--- a/keychain/src/extkey_bip32.rs
+++ b/keychain/src/extkey_bip32.rs
@@ -243,6 +243,22 @@ impl ChildNumber {
 			ChildNumber::Normal { .. } => false,
 		}
 	}
+
+	/// Returns Key index which is within [0, 2^31 - 1].
+	pub fn index(&self) -> u32 {
+		match *self {
+			ChildNumber::Hardened { index } => index,
+			ChildNumber::Normal { index } => index,
+		}
+	}
+
+	/// Create a new ChildNumber by increase the index, panics if index is i32::MAX.
+	pub fn next(&self) -> Self {
+		match *self {
+			ChildNumber::Hardened { index } => ChildNumber::from_hardened_idx(index + 1),
+			ChildNumber::Normal { index } => ChildNumber::from_normal_idx(index + 1),
+		}
+	}
 }
 
 impl From<u32> for ChildNumber {

--- a/keychain/src/keychain.rs
+++ b/keychain/src/keychain.rs
@@ -26,17 +26,6 @@ use crate::util::secp::key::{PublicKey, SecretKey};
 use crate::util::secp::pedersen::Commitment;
 use crate::util::secp::{self, Message, Secp256k1, Signature};
 
-/// Key as a recipient
-#[derive(Clone, Debug)]
-pub struct RecipientKey {
-	/// As recipient of non-interactive transaction, the key derivation path of the public address.
-	pub recipient_key_id: Identifier,
-	/// The public key of the recipient public address
-	pub recipient_pub_key: PublicKey,
-	/// The private key of the recipient public address
-	pub recipient_pri_key: SecretKey,
-}
-
 /// Extended Keychain
 #[derive(Clone, Debug)]
 pub struct ExtKeychain {

--- a/keychain/src/lib.rs
+++ b/keychain/src/lib.rs
@@ -35,7 +35,7 @@ mod types;
 
 pub mod keychain;
 pub use crate::extkey_bip32::ChildNumber;
-pub use crate::keychain::{ExtKeychain, RecipientKey};
+pub use crate::keychain::ExtKeychain;
 pub use crate::types::{
 	BlindSum, BlindingFactor, Error, ExtKeychainPath, Identifier, Keychain, IDENTIFIER_SIZE,
 };

--- a/keychain/src/types.rs
+++ b/keychain/src/types.rs
@@ -213,7 +213,7 @@ impl Identifier {
 		let mut retval = String::from("m");
 		assert!(p.path.len() >= p.depth as usize);
 		for i in 0..p.depth {
-			retval.push_str(&format!("/{}", <u32>::from(p.path[i as usize])));
+			retval.push_str(&format!("/{}", p.path[i as usize]));
 		}
 		retval
 	}


### PR DESCRIPTION
Some minor refactoring:
1. Move `RecipientKey` structure from node to wallet.
2. `ChildNumber` add `next` method for the quality of dev life.
3. `Identifier::to_bip_32_string` differentiate between **non-hardened** and **hardened** path:  for example `m/0'/0'` for **hardened** path, `m/0/0` for **non-hardened** path.


