### PR TITLE
fix: peer_write load cpu 100% on exception case

### DIFF
--- a/p2p/src/peers.rs
+++ b/p2p/src/peers.rs
@@ -371,6 +371,9 @@ impl Peers {
 	pub fn check_all(&self, total_difficulty: Difficulty, height: u64) {
 		for p in self.connected_peers().iter() {
 			if let Err(e) = p.send_ping(total_difficulty, height) {
+				//todo: above 'send_ping' will always success until the mpsc::sync_channel is full,
+				// since it just sends to a mpsc::SyncSender other than a real network sending.
+				// then, how to detect a pinging failure here?
 				debug!("Error pinging peer {:?}: {:?}", &p.info.addr, e);
 				let mut peers = match self.peers.try_write_for(LOCK_TIMEOUT) {
 					Some(peers) => peers,


### PR DESCRIPTION
It happened multiple times (both in Grin and Gotts binary) that the CPU load 100% on `peer_write` thread. I guess it goes to the unlimited loop condition for retrying the send but always fail.

![image](https://user-images.githubusercontent.com/1852227/71577502-5c498200-2b2f-11ea-9e8a-155c006d7752.png)
